### PR TITLE
[FIX]ルーティング設定の指定先を修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "posts#index"
+  root "tasks#index"
 end


### PR DESCRIPTION
# 概要
- ルーティングのrootをtasksではなくpostsにしていたため、修正