### PR TITLE
[ADD]#16 パスワード変更画面を作成

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -23,7 +23,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # パスワード変更画面
   def edit_password
-    @user = current_user
   end
 
   def update_password
@@ -31,7 +30,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       # 自動ログアウトさせないように再ログイン
       bypass_sign_in(current_user)
       flash[:notice] = "パスワードを更新しました"
-      redirect_to edit_password_path
+      redirect_to users_edit_password_path
     else
       flash.now[:alert] ="なんかパスワードにやらかしがあります"
       render :edit_password

--- a/app/views/users/registrations/edit_password.html.erb
+++ b/app/views/users/registrations/edit_password.html.erb
@@ -1,0 +1,44 @@
+<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ユーザー設定</h2>
+  </div>
+
+  <%= form_with model: current_user, url: users_update_password_path, method: :patch, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
+    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+      <%= render "users/shared/error_messages", resource: current_user %> <!-- エラー発生時の部分テンプレート -->
+
+      <!-- パスワード -->
+      <div>
+        <%= f.label :current_password, "今のパスワード", class: "block text-sm/6 font-medium text-neutral"%>
+        <div class="mt-2">
+          <%= f.password_field :current_password, autocomplete: "current-password" , class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <%= f.label :password, "新しいパスワード", class: "block text-sm/6 font-medium text-neutral"%>
+      </div>
+      <% if @minimum_password_length %>
+        <em class="text-sm text-gray-500">(<%= @minimum_password_length %>文字以上でしくよろ)</em>
+      <% end %>
+      <div class="mt-2">
+        <%= f.password_field :password, autocomplete: "new-password", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral  outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "新しいパスワード確認", class: "block text-sm/6 font-medium text-neutral"%>
+        <div class="mt-2">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password" , class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+        <%= f.submit "パスワードを変更する"%>
+      </div>
+    </div>
+  <% end %>
+
+  <div>
+    <%= link_to "パスワードを忘れた場合(未設定)", "#" %>
+  </div>
+</div>

--- a/app/views/users/registrations/edit_profile.html.erb
+++ b/app/views/users/registrations/edit_profile.html.erb
@@ -30,10 +30,10 @@
   <% end %>
 
   <div>
-    <%= link_to "パスワード変更(リンク未設定)", :back %>
+    <%= link_to "パスワード変更", :users_edit_password %>
   </div>
 
   <div>
-    <%= link_to "退会はこちら(リンク未設定)", :back %>
+    <%= link_to "退会はこちら(リンク未設定)", "#" %>
   </div>
 </div>


### PR DESCRIPTION
close #46 

# 概要
- パスワードを変更できるようにする
- ユーザー設定画面から飛べるパスワード変更画面を作成
    - 現在のパスワード、新しいパスワード、新しいパスワード確認項目を用意
    - パスワードを変更するボタンを押すと、ユーザー設定には戻らずrender(画面遷移図ではユーザー設定に遷移していたが、ユーザビリティのために同画面を表示)
    - パスワードを忘れた場合というリンクを用意する(パスワードリセット)
- コントローラー調整
- ルーティング調整(結局前回からコードに修正なし)

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/5ed1eafb2434df2ade7a44b72daead67.png)](https://gyazo.com/5ed1eafb2434df2ade7a44b72daead67)