### PR TITLE
[ADD]#17 ユーザー退会機能を作成

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,9 +58,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    current_user.destroy
+    flash[:notice] = "ユーザーを削除しました"
+    redirect_to :root
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/views/users/registrations/edit_profile.html.erb
+++ b/app/views/users/registrations/edit_profile.html.erb
@@ -29,11 +29,13 @@
     </div>
   <% end %>
 
-  <div>
-    <%= link_to "パスワード変更", :users_edit_password %>
-  </div>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <div>
+      <%= link_to "パスワード変更", :users_edit_password %>
+    </div>
 
-  <div>
-    <%= link_to "退会はこちら(リンク未設定)", "#" %>
+    <div class="mt-4 text-warning">
+      <%= link_to "退会はこちら", :users_unsubscribe_confirm %>
+    </div>
   </div>
 </div>

--- a/app/views/users/registrations/unsubscribe_confirm.html.erb
+++ b/app/views/users/registrations/unsubscribe_confirm.html.erb
@@ -1,0 +1,21 @@
+<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ユーザー退会</h2>
+  </div>
+
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <div class="mt-10 text-center text-neutral">
+      <p>退会すると、これまでの保存データが全て消えてしまします。</p>
+      <p>2度と戻りません。</p>
+      <p class="text-warning">本当に退会しますか？</p>
+    </div>
+  </div>
+
+  <div class="actions mt-8 flex w-full justify-center rounded-md bg-warning px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+    <%= button_to "退会する", users_destroy_path, method: :delete %>
+  </div>
+
+  <div class="mt-8 text-center">
+    <%= link_to "やっぱりやめる", users_edit_profile_path %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,9 @@ Rails.application.routes.draw do
     # パスワード変更
     get "users/edit_password", to: "users/registrations#edit_password"
     patch "users/update_password", to: "users/registrations#update_password"
-    # 退会 TODO: 未作成
-
+    # 退会機能
+    get "users/unsubscribe_confirm", to: "users/registrations#unsubscribe_confirm"
+    delete "users/destroy", to: "users/registrations#destroy"
     # Defines the root path route ('/') トップページ
     root to: "devise/sessions#new"
   end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
           "base-100": "#e3e0dc", // 薄グレー
           "info": "#5862ab", // 青
           "success": "#5862ab", // 青
-          "warning": "#8d7683", // 赤
+          "warning": "#E1335E", // 濃いピンク
           "error": "#8d7683", /// 赤
           },
         },


### PR DESCRIPTION
close #54 

# 概要
- ユーザー退会機能をつける
- データ復元は考えておらず、DBリソース量も限られているので今回は物理削除とする

# 主な変更内容
- `app/controllers/users/registrations_controller.rb` にdestroyメソッドを追加
- `config/routes.rb` で退会確認ページと退会アクションのルーティングを作成
- `app/views/users/registrations/unsubscribe_confirm.html.erb` という退会確認ページを作成
- `app/views/users/registrations/edit_profile.html.erb` で退会ページリンクを追加
- `tailwind.config.js ` で濃いピンクの色を追加

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/1f2530f3e54eb33d8daf565ba8bc87ee.png)](https://gyazo.com/1f2530f3e54eb33d8daf565ba8bc87ee)