### PR TITLE
[ADD]#17 オートログイン機能を追加

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -23,14 +23,12 @@
     <%= f.password_field :password, autocomplete: "current-password", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral  outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
   </div>
 
-  <!-- MVP時点では使用しない
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-  -->
+  <div class="mt-4 flex items-center">
+    <% if devise_mapping.rememberable? %>
+      <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+      <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-neutral" %>
+    <% end %>
+  </div>
 
   <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
     <%= f.submit "ログイン" %>


### PR DESCRIPTION
close #49 

# 概要
- deviseのrememberable機能を使って、ログイン状態を保存する機能をつける

# 主な変更内容
- `app/models/user.rb` ではすでに`:rememberable` ついていたのでモデルは変更なし
- `app/views/users/sessions/new.html.erb ` でログインボタンの上に「ログイン状態を保持する」チェックボックスを追加

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/2882c6f190a81ce831e5f7d9360f51e5.png)](https://gyazo.com/2882c6f190a81ce831e5f7d9360f51e5)