### PR TITLE
[ADD]#20 Google認証機能を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,10 @@ gem "dotenv-rails"
 # 日本語化
 gem "rails-i18n"
 
+# Google認証
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,15 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -138,6 +145,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.0)
+    jwt (2.10.1)
+      base64
     language_server-protocol (3.17.0.3)
     logger (1.6.2)
     loofah (2.23.1)
@@ -154,6 +163,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.2)
     msgpack (1.7.5)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.1)
       date
       net-protocol
@@ -176,6 +189,28 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.3)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -199,6 +234,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -287,6 +326,9 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     slop (3.6.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -307,7 +349,9 @@ GEM
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
     useragent (0.16.10)
+    version_gem (1.1.8)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -343,6 +387,8 @@ DEPENDENCIES
   dotenv-rails
   jbuilder
   jsbundling-rails
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   pry-byebug
   pry-remote

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,32 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # binding.pry
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  def callback_for(provider)
+    @omniauth = request.env["omniauth.auth"]
+    info = User.find_oauth(@omniauth)
+    @user = info[:user]
+    # もしUser情報があってSNSと紐づいていればログイン、User情報がなければ登録を促す
+    if @user.persisted? # User情報が保存できているか？
+      sign_in_and_redirect @user, event: :authentication
+      # is_navigational_formatはフラッシュメッセージを発行する必要があるかどうか確認する
+      # capitalizeは先頭文字を大文字に、それ以外を小文字にする
+      set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
+    else
+      # TODO: これだと新規登録画面で残りの情報（ユーザー名など）を入れさせるスタイルになるので、自動で登録されるシステムにしたい
+      @sns = info[:sns]
+      render "users/registrations/new" # ビューを表示
+    end
+  end
+
+  def failure
+    redirect_to root_path and return
+  end
+
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,72 @@
 class User < ApplicationRecord
+  # ユーザーを削除したら、睡眠記録も一緒に消える
+  has_many :sleep_logs, dependent: :destroy
+  # SNS認証、今後認証機能付け足す用にhas_many
+  has_many :sns_credential, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         # Omniauth用
+         :omniauthable, omniauth_providers: %i[google_oauth2]
+
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
-  # ユーザーを削除したら、睡眠記録も一緒に消える
-  has_many :sleep_logs, dependent: :destroy
+
+  class << self # メソッソ冒頭につけるself.を省略
+    # SnsCredentialsテーブルにデータがない場合
+    def without_sns_data(auth)
+      user = User.where(email: auth.info.email).first
+
+      if user.present? # 同じメールアドレスが存在する場合、SnsCredentialだけ作る
+        sns = SnsCredential.create(
+          uid: auth.uid,
+          provider: auth.provider,
+          user_id: user.id
+        )
+      else # ユーザー自体存在しない場合、UserとSnsCredential両方作る
+        user = User.create(
+          name: auth.info.name, # SNSの名前を取得
+          email: auth.info.email,
+          password: Devise.friendly_token(10) # 即席のランダムパスワード
+        )
+        sns = SnsCredential.create(
+          user_id: user.id,
+          uid: auth.uid,
+          provider: auth.provider
+        )
+      end
+      { user:, sns: } # ハッシュ形式で呼び出し元にreturn
+    end
+
+    # SnsCredentialテーブルにデータがある場合
+    def with_sns_data(auth, snscredential)
+      user = User.where(id: snscredential.user_id).first
+      # Userの中身が空っぽの場合
+      if user.blank?
+        user = User.create(
+          name: auth.info.name, # SNSの名前を取得
+          email: auth.info.email,
+          password: Devise.friendly_token(10)
+        )
+      end
+      { user: }
+    end
+
+    # Googleアカウントの情報をそれぞれの変数に格納して上記のメソッドに振り分ける
+    def find_oauth(auth)
+      uid = auth.uid
+      provider = auth.provider
+      snscredential = SnsCredential.where(uid:, provider:).first
+      if snscredential.present?
+        user = with_sns_data(auth, snscredential)[:user]
+        sns = snscredential
+      else
+        user = without_sns_data(auth)[:user]
+        sns = without_sns_data(auth)[:sns]
+      end
+      { user:, sns: } # ハッシュ形式でreturn
+    end
+  end
 end

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -6,6 +6,13 @@
   <%= link_to "新規登録", new_registration_path(resource_name) %><br />
 <% end %>
 
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false } %><br />
+  <% end %>
+<% end %>
+
+
 <%
 =begin%>
  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,8 @@ services:
       context: .
       # Dockerfile.devに基づくよう指定
       dockerfile: Dockerfile.dev
+    env_file:
+      - .env
     command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
     tty: true
     stdin_open: true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,6 +273,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  # Google OAuth2用
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {} # , scope: 'email', redirect_uri: "#{ENV['HOST']}/users/auth/google_oauth2/callback"
+  # 開発環境のデバッグ用
+  OmniAuth.config.logger = Rails.logger if Rails.env.development?
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,8 @@ Rails.application.routes.draw do
   # ログイン機能
   devise_for :users, controllers: {
     registrations: "users/registrations", # ユーザー設定など用
-    passwords: "users/passwords" # パスワードリセット用
+    passwords: "users/passwords", # パスワードリセット用
+    omniauth_callbacks: "users/omniauth_callbacks" # Google認証用
   }
 
   devise_scope :user do

--- a/db/migrate/20250515055930_add_omniauth_to_users.rb
+++ b/db/migrate/20250515055930_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/migrate/20250515064716_create_sns_credentials.rb
+++ b/db/migrate/20250515064716_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :provider
+      t.string :uid
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_11_030317) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_15_064716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_030317) do
     t.index ["user_id"], name: "index_sleep_logs_on_user_id"
   end
 
+  create_table "sns_credentials", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email"
@@ -59,6 +68,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_030317) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -67,4 +78,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_030317) do
   add_foreign_key "comments", "sleep_logs"
   add_foreign_key "napping_times", "sleep_logs"
   add_foreign_key "sleep_logs", "users"
+  add_foreign_key "sns_credentials", "users"
 end

--- a/test/fixtures/sns_credentials.yml
+++ b/test/fixtures/sns_credentials.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/sns_credential_test.rb
+++ b/test/models/sns_credential_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SnsCredentialTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #47 
作業時間: 約6時間

# 概要
DeviseとOmniauthを使ってGoogle認証機能を作る
ただし、UserモデルのnameはGoogleに登録している名前を利用できるようにする

# 主な変更内容
- OAuthの申請
- gem 'omniauth-google-oauth2’ とgem "omniauth-rails_csrf_protection” をインストール(CSRF対策)
- 開発環境: .env／本番環境: Renderで環境変数を設定
- UserモデルにOAuth用カラムを追加
- コールバック用コントローラー作成
- SnsCredentialモデル作成
- ルーティングの設定
- ビューにログイン用ボタンを追加

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/37503b474d1f615e8a7271e3c034bec1.png)](https://gyazo.com/37503b474d1f615e8a7271e3c034bec1)