### PR TITLE
[ADD]#24 Googleフォームのお問い合わせをRails風味に埋め込み

### DIFF
--- a/app/controllers/footers_controller.rb
+++ b/app/controllers/footers_controller.rb
@@ -1,4 +1,31 @@
+require "net/http" # 汎用データ転送プロトコルHTTPを扱うライブラリ. フォームの情報を送信するのに使う
+require "uri" # URI を扱うためのモジュールで、URI.parseのメソッドが使えるようになる
+
 class FootersController < ApplicationController
+  def contact_form
+  end
+  def create
+    # 送信先の文字列をURIオブジェクトに変換
+    if params[:kind_of_contact].blank?
+      flash[:alert] = "お問い合わせの種類を1つ以上選択してください"
+      render :contact_form and return
+    end
+    uri = URI.parse("https://docs.google.com/forms/d/e/1FAIpQLSfOQy2m7AFpztirJzxPL0l-GUE5Q6FjohAyRZGfq42TCOB3Rw/formResponse")
+
+    # Googleフォームの各エントリIDに合わせてフォーム値をセット
+    form_data = {
+      "emailAddress" => params[:email], # メールアドレス
+      "entry.2002479067" => params[:name], # お名前
+      "entry.1153015411" => params[:kind_of_contact], # お問い合わせの種類
+      "entry.149706489"  => params[:content], # お問合せ内容
+      "entry.323478922" => params[:need_to_reply] # お問い合わせ内容に対する返信の要否
+    }
+
+    Net::HTTP.post_form(uri, form_data)
+
+    flash[:notice] = "お問い合わせいただきありがとうございます"
+    redirect_to root_path
+  end
   def terms_of_service; end
   def privacy_policy; end
 end

--- a/app/views/footers/contact_form.html.erb
+++ b/app/views/footers/contact_form.html.erb
@@ -1,0 +1,68 @@
+<div class="relative my-12 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h2 class="mt-10 text-center text-2xl/9 font-bold">お問い合わせ</h2>
+  </div>
+
+  <%= form_with url: "/footers/contact_form", method: :post, local: true, data: { turbo: false } do |f| %>
+    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+      <!-- メールアドレス -->
+      <div class="mt-4">
+        <%= f.label :email, "メールアドレス", class: "block text-sm/6 font-medium" %>
+        <div class="mt-2">
+          <%= email_field_tag :email, params[:email].presence || nil, required: true, placeholder: "mail@example.com", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <!-- お名前 -->
+      <div>
+        <%= f.label :name, "お名前", class: "block text-sm/6 font-medium" %>
+        <div class="mt-2">
+          <%= text_field_tag :name, params[:name].presence || nil, required: true, placeholder: "ポル太郎", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <!-- お問い合わせの種類 -->
+      <div class="mt-4">
+        <%= f.label :kind_of_contact, "お問い合わせの種類", class: "block" %>
+        <div class="mt-2 space-y-2">
+          <% kinds = [
+            "バグ・エラーなど不具合に関する報告",
+            "感想",
+            "改善要請",
+            "アプリに関する問い合わせ",
+            "その他"
+          ] %>
+
+          <% kinds.each_with_index do |kind, index| %>
+            <div class="flex items-center space-x-2">
+              <%= check_box_tag 'kind_of_contact[]', kind, params[:kind_of_contact].presence || false, id: "kind_of_contact_#{index}",  class: "form-checkbox h-4 w-4 text-indigo-600 border-gray-300 rounded" %>
+              <%= label_tag "kind_of_contact_#{index}", kind, class: "text-sm text-gray-700" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+
+      <!-- お問い合わせ内容 -->
+      <div class="mt-4">
+        <%= f.label :content, "お問い合わせ内容", class: "block" %>
+        <div class="mt-2">
+          <%= text_area_tag :content, params[:content].presence || nil, required: true, rows: 4, placeholder: "ご質問やご要望などをご記入ください", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <!-- お問い合わせ内容に対する返信の要否 -->
+      <div class="mt-4">
+        <%= f.label :need_to_reply, "お問い合わせ内容に対する返信の要否", class: "block" %>
+        <div class="mt-2">
+          <%= select_tag :need_to_reply, options_for_select(["はい", "いいえ"], params[:need_to_reply]), class: "form_field block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        </div>
+      </div>
+
+      <!-- 送信ボタン -->
+      <div class="mt-8">
+        <%= f.submit "送信", class: "actions flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,8 +1,8 @@
 <!-- フラッシュメッセージ表示用(いづれ、success用のフラッシュメッセージも作りたい) -->
 <% if notice %>
-  <p class="print:hidden notice success flex justify-center items-center relative mt-8 mx-auto h-16 w-[90%] bg-success rounded-xl text-primary"><%= notice %></p>
+  <p class="print:hidden notice success flex justify-center items-center mt-32 mx-auto h-16 w-[90%] bg-success rounded-xl text-primary"><%= notice %></p>
 <% end %>
 
 <% if alert %>
-  <p class="print:hidden alert error flex justify-center items-center relative mt-8 mx-auto h-16 w-[90%] bg-error rounded-xl text-primary"><%= alert %></p>
+  <p class="print:hidden alert error flex justify-center items-center mt-32 mx-auto h-16 w-[90%] bg-error rounded-xl text-primary"><%= alert %></p>
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <!-- 全体のフレックスレイアウト -->
   <div class="flex justify-between items-center w-full">
     <nav class="flex space-x-4">
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfOQy2m7AFpztirJzxPL0l-GUE5Q6FjohAyRZGfq42TCOB3Rw/viewform?usp=dialog" class="text-neutral hover:text-primary">お問い合わせ</a>
+      <%= link_to "お問い合わせ", footers_contact_form_path, class: "text-neutral hover:text-primary" %>
       <%= link_to "利用規約", footers_terms_of_service_path, class: "text-neutral hover:text-primary" %>
       <%= link_to "プライバシーポリシー", footers_privacy_policy_path, class:"text-neutral hover:text-primary" %>
     </nav>

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -1,5 +1,5 @@
 <div class="my-32 print:my-0">
-  <div class="m-16 flex justify-center items-center print:m-2">
+  <div class="mb-12 flex justify-center items-center print:m-2">
 
     <!-- 印刷時非表示: 年月選択 -->
     <div class="print:hidden">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   # リソースルート
   resources :sleep_logs, only: [ :index, :new, :edit, :update, :create, :destroy ]
 
+  # おといあわせ
+  get "/footers/contact_form", to: "footers#contact_form"
+  post "/footers/contact_form", to: "footers#create"
   # 利用規約
   get "/footers/terms_of_service", to: "footers#terms_of_service"
   # プライバシーポリシー
@@ -41,6 +44,6 @@ Rails.application.routes.draw do
     get "users/unsubscribe_confirm", to: "users/registrations#unsubscribe_confirm"
     delete "users/destroy", to: "users/registrations#destroy"
     # Defines the root path route ('/') トップページ
-    root to: "devise/sessions#new"
+    root to: "sleep_logs#index"
   end
 end


### PR DESCRIPTION
close #89 

# 概要
Googleフォームで作ったお問い合わせ画面をアプリ内に表示させる
具体的な実装記事が見つからなかったので、この実装方法については記事を執筆した
[GoogleフォームをRailsでカスタマイズする](https://zenn.dev/m_porun/articles/5c3691a22187b9)

# 主な変更内容
- Googleフォームのリンクを埋め込むのではなく、自作した入力フォームの内容をGoogleフォームへ送信する機能にした
- ```app/views/footers/contact_form.html.erb```ファイルを作成し、お問い合わせ入力画面を作成
- ```app/controllers/footers_controller.rb```で表示用アクションと送信用アクションを作成
  - HTMLデフォルトのバリデーションでは対応できない部分を送信用アクション内に記載（複数選択可能なチェックボックスで、一つも選択されていない場合送信せず再表示させる仕組みを追加）
- ルーティングを設定

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/17c81ceb0b4bb64ccf76bdc95d8c0225.png)](https://gyazo.com/17c81ceb0b4bb64ccf76bdc95d8c0225)