### PR TITLE
[FIX]#27 睡眠時間編集用のモーダルを作成

### DIFF
--- a/app/controllers/sleep_logs_controller.rb
+++ b/app/controllers/sleep_logs_controller.rb
@@ -38,7 +38,12 @@ class SleepLogsController < ApplicationController
 
       respond_to do |format|
         format.html { redirect_to sleep_logs_path(year_month: year_month), notice: "睡眠記録を保存しました" }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace("sleep-logs-table", partial: "logs_table") }
+        format.turbo_stream do # renderをまとめないと最初のrenderのみを適用してしまう
+          render turbo_stream: [ # ★修正: 配列としてまとめる
+            turbo_stream.replace("sleep-logs-table", partial: "logs_table", locals: { sleep_logs: @sleep_logs }), # テーブルの更新
+            turbo_stream.prepend("flash-messages", partial: "shared/flash", locals: { notice: "睡眠記録を保存しました", alert: nil }) # フラッシュメッセージ
+          ]
+        end
       end
     else
       respond_to do |format|
@@ -48,7 +53,10 @@ class SleepLogsController < ApplicationController
         end
         format.turbo_stream do
           # エラーがある場合はフォームをTurbo Frame内で再表示
-          render turbo_stream: turbo_stream.replace("sleep_log_frame", partial: "sleep_logs/new", locals: { sleep_log_form: @sleep_log_form }), status: :unprocessable_entity
+          render turbo_stream: [ # ★修正: 配列としてまとめる
+            turbo_stream.replace("sleep_log_frame", partial: "sleep_logs/new", locals: { sleep_log_form: @sleep_log_form }),
+            turbo_stream.prepend("flash-messages", partial: "shared/flash", locals: { notice: nil, alert: "エラーが発生しました。入力内容を確認してください。" })
+          ], status: :unprocessable_entity
         end
       end
     end
@@ -68,7 +76,13 @@ class SleepLogsController < ApplicationController
       #redirect_to sleep_logs_path(year_month: year_month), notice: "睡眠記録を更新しました" # 登録した年月のページにリダイレクト
       respond_to do |format|
         format.html { redirect_to sleep_logs_path(year_month: year_month), notice: "睡眠記録を更新しました" }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace("sleep-logs-table", partial: "logs_table") }
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.append("body", "<script>document.getElementById('my_modal_3').close();</script>"),
+            turbo_stream.replace("sleep-logs-table", partial: "logs_table", locals: { sleep_logs: @sleep_logs }),
+            turbo_stream.prepend("flash-messages", partial: "shared/flash", locals: { notice: "睡眠記録を更新しました", alert: nil })
+          ]
+        end
       end
     else
       respond_to do |format|
@@ -77,8 +91,10 @@ class SleepLogsController < ApplicationController
           render :new
         end
         format.turbo_stream do
-          # エラーがある場合はフォームをTurbo Frame内で再表示
-          render turbo_stream: turbo_stream.replace("sleep_log_frame", partial: "sleep_logs/new", locals: { sleep_log_form: @sleep_log_form }), status: :unprocessable_entity
+          render turbo_stream: [
+            turbo_stream.replace("sleep_log_frame", partial: "sleep_logs/new", locals: { sleep_log_form: @sleep_log_form }),
+            turbo_stream.prepend("flash-messages", partial: "shared/flash", locals: { notice: nil, alert: "エラーが発生しました。入力内容を確認してください。" })
+          ], status: :unprocessable_entity
         end
       end
     end

--- a/app/controllers/sleep_logs_controller.rb
+++ b/app/controllers/sleep_logs_controller.rb
@@ -73,7 +73,6 @@ class SleepLogsController < ApplicationController
     if @sleep_log_form.save
       year_month = @sleep_log_form.sleep_date.strftime("%Y-%m") # 登録されたsleep_log.dateをYYYY-MM形式に変換
       set_sleep_logs(year_month)
-      #redirect_to sleep_logs_path(year_month: year_month), notice: "睡眠記録を更新しました" # 登録した年月のページにリダイレクト
       respond_to do |format|
         format.html { redirect_to sleep_logs_path(year_month: year_month), notice: "睡眠記録を更新しました" }
         format.turbo_stream do

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,56 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="flash"
+export default class extends Controller {
+  static values = {
+    duration: Number, // フラッシュメッセージの表示時間
+  }
+
+  connect() {
+    // 接続時、フェードインアニメーション発動
+    this.element.classList.add('animate-flash-message-in')
+
+    // もし時間指定があれば、自動で消えるようにするタイマーを設定
+    if (this.durationValue) {
+      this.startFadeOutTimer();
+    }
+  }
+
+  // 自動で消えるタイマー発動
+  startFadeOutTimer() {
+const initialAnimationDelay = 600; // 0.6秒
+    this.timeout = setTimeout(() => {
+      this.close();
+    }, this.durationValue + initialAnimationDelay); // アニメーション時間 + 設定された duration
+  }
+
+  // コントローラがDOMから切断されるときにタイマーをクリア
+  disconnect() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+    console.log("Flash controller disconnected!");
+  }
+
+  // フラッシュメッセージを閉じる (手動またはタイマーで呼び出される)
+  close() {
+    // 既にフェードアウトアニメーションが適用されていないか確認
+    if (this.element.classList.contains('animate-flash-message-out')) {
+      return; // 既に消え始めている場合は何もしない
+    }
+
+    // フェードアウトアニメーションを適用
+    this.element.classList.remove('animate-flash-message-in'); // フェードインクラスを削除
+    this.element.classList.add('animate-flash-message-out');
+
+    // アニメーション終了後に要素をDOMから削除
+    // 'animationend' イベントは、アニメーションの終了を検知する
+    this.element.addEventListener('animationend', (event) => {
+      // 特定のアニメーション（ここでは animate-flash-message-out）の終了のみを処理する
+      if (event.animationName === 'flashMessageOut') {
+        this.element.remove();
+        console.log("Flash message removed from DOM.");
+      }
+    }, { once: true }); // イベントリスナーは一度だけ実行されるようにする
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,14 +2,10 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-// from~Toggle)まで追加。TailwindCSSコンポーネントをインポート
-import { Application } from "@hotwired/stimulus"
-
-const application = Application.start();
-
-// TailwindCSS Components https://github.com/excid3/tailwindcss-stimulus-components#basic-usage TODO: 不要なものがあれば消すこと
-import { Modal } from "tailwindcss-stimulus-components"
-application.register('modal', Modal)
+import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ["dialog"] // daisyUIモーダルのdialogに合わせる
+  connect() {
+  }
+
+  close() {
+    if (this.hasDialogTarget) { //もしモーダルが出ていたら発動する
+    this.dialogTarget.close(); // daisyUIに合わせてhideではなくcloseとする
+    } else {
+      console.error("モーダル閉じれぬ");
+    }
+  }
+
+  // なぜかこれがついていないと、キャッシュないときに初めてモーダル開く際turbo-frameを読み込まない問題が起きる
+  show() {
+    if (this.hasDialogTarget) {
+      this.dialogTarget.showModal();
+    } else {
+      console.error("モーダル開かぬ(stimulus版)");
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,9 +29,6 @@
     <!-- Turbo使用時、アセットが更新されたときに再ロードする -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-
-    <!-- Turbo Frameでモーダルの設定 -->
-    <%= turbo_frame_tag "modal" %>
   </head>
 
   <body class="text-neutral kiwi-maru-regular base-100 w-screen print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,8 +1,18 @@
 <!-- フラッシュメッセージ表示用(いづれ、success用のフラッシュメッセージも作りたい) -->
-<% if notice %>
-  <p class="print:hidden notice success flex justify-center items-center mt-32 mx-auto h-16 w-[90%] bg-success rounded-xl text-primary"><%= notice %></p>
-<% end %>
+<div id="flash-messages" class="fixed top-4 left-0 w-full z-[9999] p-4 pointer-events-none flex flex-col items-center space-y-2">
+  <% if notice %>
+    <div class="print:hidden notice success flex justify-center items-center text-center h-16 w-[90%] bg-success rounded-xl text-primary pointer-events-auto shadow-lg"
+         data-controller="flash"
+         data-flash-duration-value="2500"> <%# 2.5秒 %>
+      <%= notice %>
+    </div>
+  <% end %>
 
-<% if alert %>
-  <p class="print:hidden alert error flex justify-center items-center mt-32 mx-auto h-16 w-[90%] bg-error rounded-xl text-primary"><%= alert %></p>
-<% end %>
+  <% if alert %>
+    <div class="print:hidden alert error flex justify-center items-center h-16 w-[90%] bg-error rounded-xl text-primary pointer-events-auto shadow-lg"
+         data-controller="flash"
+         data-flash-duration-value="4500"> <%# 例えば4.5秒表示したい場合 %>
+      <%= alert %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sleep_logs/_logs_table.html.erb
+++ b/app/views/sleep_logs/_logs_table.html.erb
@@ -1,4 +1,5 @@
-<tbody>
+
+
   <% @sleep_logs.each do |sleep_log| %> <!-- 月初から月末までの日付を繰り返し表示する -->
     <tr class="border border-secondary bg-primary">
       <td class="border border-secondary bg-primary print:py-2"><%= sleep_log.sleep_date.day %></td>
@@ -35,18 +36,16 @@
         <%= sleep_log.comment&.comment || '' %>
       </td>
 
-
       <td class="print:hidden border border-secondary bg-primary">
           <% if sleep_log.persisted? %>
-            <span class="material-symbols-outlined inline-flex">
-              <%= link_to 'edit_square', edit_sleep_log_path(sleep_log) %>
-            </span>
+            <button class="btn w-full" onclick="my_modal_3.showModal()">
+              <%= link_to 'edit_square', edit_sleep_log_path(sleep_log), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined inline-flex" %>
+            </button>
           <% else %>
-            <span class="material-symbols-outlined inline-flex">
-              <%= link_to 'edit_square', new_sleep_log_path(sleep_date: sleep_log.sleep_date) %> <!-- indexで設定した日付一覧から日付を取得 -->
-            </span>
+            <button class="btn w-full" onclick="my_modal_3.showModal()">
+              <%= link_to 'edit_square', new_sleep_log_path(sleep_date: sleep_log.sleep_date), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined inline-flex" %> <!-- indexで設定した日付一覧から日付を取得 -->
+            </button>
           <% end %>
       </td>
     </tr>
   <% end %>
-</tbody>

--- a/app/views/sleep_logs/edit.html.erb
+++ b/app/views/sleep_logs/edit.html.erb
@@ -1,49 +1,51 @@
 <!-- 編集画面 -->
-<div class="flex justify-center items-center z-50 mt-16">
-  <%= form_with(url: sleep_log_path,  model: @sleep_log_form, method: :patch, local: true, data: { turbo: false }) do |f| %>
+<%= turbo_frame_tag 'sleep_log_frame' do %>
+        <div class="flex justify-center items-center">
+          <%= form_with(url: sleep_log_path,  model: @sleep_log_form, method: :patch, html: { data: { action: 'turbo:submit-end->modal#close' } }) do |f| %>
 
-    <div>
-      <%= f.label :sleep_date, '起きた日付' %>
-      <%= f.date_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true %> <!-- f.objectに値があれば日付を、なければ探す -->
-    </div>
+            <div>
+              <%= f.label :sleep_date, '起きた日付' %>
+              <%= f.date_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true %> <!-- f.objectに値があれば日付を、なければ探す -->
+            </div>
 
-    <div>
-      <%= f.label :go_to_bed_at, "昨夜布団に入った時刻" %>
-      <%= f.time_field :go_to_bed_at %>
-    </div>
+            <div>
+              <%= f.label :go_to_bed_at, "昨夜布団に入った時刻" %>
+              <%= f.time_field :go_to_bed_at %>
+            </div>
 
-    <div>
-      <%= f.label :fell_asleep_at, "昨夜寝た時刻" %>
-      <%= f.time_field :fell_asleep_at %>
-    </div>
+            <div>
+              <%= f.label :fell_asleep_at, "昨夜寝た時刻" %>
+              <%= f.time_field :fell_asleep_at %>
+            </div>
 
-    <div>
-      <%= f.label :woke_up_at, "今朝目覚めた時刻" %>
-      <%= f.time_field :woke_up_at %>
-    </div>
+            <div>
+              <%= f.label :woke_up_at, "今朝目覚めた時刻" %>
+              <%= f.time_field :woke_up_at %>
+            </div>
 
-    <div>
-      <%= f.label :leave_bed_at, "今朝布団から出た時刻" %>
-      <%= f.time_field :leave_bed_at %>
-    </div>
+            <div>
+              <%= f.label :leave_bed_at, "今朝布団から出た時刻" %>
+              <%= f.time_field :leave_bed_at %>
+            </div>
 
-    <div>
-      <%= f.label :awakenings_count, "中途覚醒（回数）" %>
-      <%= f.number_field :awakenings_count, min: 0 %> <!-- デフォルトで0が入力されている -->
-    </div>
+            <div>
+              <%= f.label :awakenings_count, "中途覚醒（回数）" %>
+              <%= f.number_field :awakenings_count, min: 0 %> <!-- デフォルトで0が入力されている -->
+            </div>
 
-    <div>
-      <%= f.label :napping_time, "昼寝時間（分）" %>
-      <%= f.number_field :napping_time, min: 0 %> <!-- デフォルトで0が入力されている -->
-    </div>
+            <div>
+              <%= f.label :napping_time, "昼寝時間（分）" %>
+              <%= f.number_field :napping_time, min: 0 %> <!-- デフォルトで0が入力されている -->
+            </div>
 
-    <div>
-      <%= f.label :comment, "備考(42文字まで)" %>
-      <%= f.text_area :comment, max: 42 %>
-    </div>
+            <div>
+              <%= f.label :comment, "備考(42文字まで)" %>
+              <%= f.text_area :comment, max: 42 %>
+            </div>
 
-    <div class="flex justify-end">
-      <%= f.submit "登録", class: "bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4 rounded"%>
-    </div>
-  <% end %>
-</div>
+            <div class="flex justify-end">
+              <%= f.submit "登録", class: "bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4 rounded"%>
+            </div>
+          <% end %>
+        </div>
+<% end %>

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -34,10 +34,21 @@
     <div class="hidden print:block text-center font-bold">
       <%= current_user.name %>
     </div>
+
+    <!-- Turbo Frameでモーダルの設定 -->
+    <dialog id="my_modal_3" class="modal" data-controller="modal" data-modal-target="dialog">
+      <div class="modal-box h-auto">
+        <%= turbo_frame_tag "sleep_log_frame" %>
+          <form method="dialog">
+            <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+          </form>
+        </div>
+      </dialog>
+    </div>
   </div>
 
   <!-- 睡眠記録テーブル -->
-  <div id="sleep-logs-table", class="mx-32 flex justify-center"> <!-- テーブルごとに一意の識別子を用意することで、指定の部分のみを更新できるようにしている  -->
+  <div class="mx-32 flex justify-center">
     <table class="table-fixed w-full text-center text-sm text-neutral print:leading-none print:py-[15px]">
       <thead>
         <tr class="print:text-[12px]">
@@ -55,7 +66,9 @@
           <th class="w-8 print:hidden border border-secondary bg-primary">編集</th>
         </tr>
       </thead>
-      <%= render 'logs_table' %>
+      <tbody id="sleep-logs-table">
+        <%= render 'logs_table' %>
+      </tbody>
     </table>
   </div>
 </div>

--- a/app/views/sleep_logs/new.html.erb
+++ b/app/views/sleep_logs/new.html.erb
@@ -1,48 +1,52 @@
 <!-- 新規作成画面 -->
-<div class="fixed flex justify-center items-center z-50 mt-8">
-  <%= form_with(url: sleep_logs_path, model: @sleep_log_form, method: :post, local: true, data: { turbo: false }) do |f| %>
-    <div>
-      <%= f.label :sleep_date, '起きた日付' %>
-      <%= f.date_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true %> <!-- f.objectに値があれば日付を、なければ探す -->
-    </div>
+<%= turbo_frame_tag 'sleep_log_frame' do %>
 
-    <div>
-      <%= f.label :go_to_bed_at, "昨夜布団に入った時刻" %>
-      <%= f.time_field :go_to_bed_at %>
-    </div>
+        <div class="flex justify-center items-center">
+        <%= form_with(url: sleep_logs_path, model: @sleep_log_form, method: :post, html: { data: { action: 'turbo:submit-end->modal#close' } }) do |f| %>
+          <div>
+            <%= f.label :sleep_date, '起きた日付' %>
+            <%= f.date_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true %> <!-- f.objectに値があれば日付を、なければ探す -->
+          </div>
 
-    <div>
-      <%= f.label :fell_asleep_at, "昨夜寝た時刻" %>
-      <%= f.time_field :fell_asleep_at %>
-    </div>
+          <div>
+            <%= f.label :go_to_bed_at, "昨夜布団に入った時刻" %>
+            <%= f.time_field :go_to_bed_at %>
+          </div>
 
-    <div>
-      <%= f.label :woke_up_at, "今朝目覚めた時刻" %>
-      <%= f.time_field :woke_up_at  %>
-    </div>
+          <div>
+            <%= f.label :fell_asleep_at, "昨夜寝た時刻" %>
+            <%= f.time_field :fell_asleep_at %>
+          </div>
 
-    <div>
-      <%= f.label :leave_bed_at, "今朝布団から出た時刻" %>
-      <%= f.time_field :leave_bed_at  %>
-    </div>
+          <div>
+            <%= f.label :woke_up_at, "今朝目覚めた時刻" %>
+            <%= f.time_field :woke_up_at  %>
+          </div>
 
-    <div>
-      <%= f.label :awakenings_count, "中途覚醒（回数）" %>
-      <%= f.number_field :awakenings_count, min: 0 %> <!-- デフォルトで0が入力されている -->
-    </div>
+          <div>
+            <%= f.label :leave_bed_at, "今朝布団から出た時刻" %>
+            <%= f.time_field :leave_bed_at  %>
+          </div>
 
-    <div>
-      <%= f.label :napping_time, "昼寝時間（分）" %>
-      <%= f.number_field :napping_time, min: 0 %> <!-- デフォルトで0が入力されている -->
-    </div>
+          <div>
+            <%= f.label :awakenings_count, "中途覚醒（回数）" %>
+            <%= f.number_field :awakenings_count, min: 0 %> <!-- デフォルトで0が入力されている -->
+          </div>
 
-    <div>
-      <%= f.label :comment, "備考(42文字まで)" %>
-      <%= f.text_area :comment, max: 42 %>
-    </div>
+          <div>
+            <%= f.label :napping_time, "昼寝時間（分）" %>
+            <%= f.number_field :napping_time, min: 0 %> <!-- デフォルトで0が入力されている -->
+          </div>
 
-    <div class="flex justify-end">
-      <%= f.submit "登録", class: "bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4 rounded"%>
-    </div>
-  <% end %>
-</div>
+          <div>
+            <%= f.label :comment, "備考(42文字まで)" %>
+            <%= f.text_area :comment, max: 42 %>
+          </div>
+
+          <div class="flex justify-end">
+            <%= f.submit "登録", class: "bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4 rounded"%>
+          </div>
+        <% end %>
+        </div>
+
+<% end %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,20 +9,20 @@ module.exports = {
     extend: {
       keyframes: {
         flashMessageIn: { // スライドイン・フェードイン
-          '0%': { opacity: 0, transform: 'translateY(100%)'},
-          '20%': { opacity: 1, transform: 'translateY(0)' },
+          '0%': { opacity: 0, transform: 'translateY(0)'},
+          '20%': { opacity: 1, transform: 'translateY(100%)' },
           },
           flashMessageOut: { // スライドアウト・フェードアウト
-            '80%': { opacity: 1, transform: 'translateY(0)' },
-            '100%': { opacity: 0, transform: 'translateY(100%)' },
+            '80%': { opacity: 1, transform: 'translateY(100%)' },
+            '100%': { opacity: 0, transform: 'translateY(0)' },
           },
         },
         animation: {
-          
-        }
+          'flash-message-in': 'flashMessageIn 0.5s ease-out forwards', // 最初早く後遅く、0.5秒後に発動
+          'flash-message-out': 'flashMessageOut 0.5s ease-in forwards', // 最初遅く後早く
+        },
       },
     },
-  },
   plugins: [require("daisyui")],
   daisyui: {
     themes: [
@@ -42,4 +42,4 @@ module.exports = {
       ],
       darkTheme: false, // ダークテーマを採用しない
     },
-}
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,24 @@ module.exports = {
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ],
+  theme: {
+    extend: {
+      keyframes: {
+        flashMessageIn: { // スライドイン・フェードイン
+          '0%': { opacity: 0, transform: 'translateY(100%)'},
+          '20%': { opacity: 1, transform: 'translateY(0)' },
+          },
+          flashMessageOut: { // スライドアウト・フェードアウト
+            '80%': { opacity: 1, transform: 'translateY(0)' },
+            '100%': { opacity: 0, transform: 'translateY(100%)' },
+          },
+        },
+        animation: {
+          
+        }
+      },
+    },
+  },
   plugins: [require("daisyui")],
   daisyui: {
     themes: [


### PR DESCRIPTION
close #16 
20時間

# 概要
睡眠記録をモーダルで編集できるようにする
フラッシュメッセージをアニメーションで表示

# 主な変更
- モーダル表示領域を`app/views/sleep_logs/index.html.erb`で設定、daisyUIのモーダルを採用
- 編集ボタンを押すとturbo-frameが呼び出されてnew / edit画面がモーダル上に表示されるようにする
- submitボタンを押すとモーダルが自動で閉じるようstimulusでカスタマイズ
- 編集後、睡眠記録テーブルのヘッダー以下の部分が新しい記録に置き換わるようにする(replace)
- フラッシュメッセージがアニメーションで表示されるように変更
- アニメーション表示後はフラッシュメッセージが消えるようにstimulusでカスタマイズ

- 現時点ではバリデーションエラー時の表示を設定できていないため、バリデーションissue時に修正予定

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/1fa1481e31e87a56e468e5776cd522b5.png)](https://gyazo.com/1fa1481e31e87a56e468e5776cd522b5)