### PR TITLE
[FIX]#29 見た目を整える

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # ログイン機能でnameパラメーターを許可する
   before_action :configure_permitted_parameters, if: :devise_controller?
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # FIXME: 406エラー対策。デプロイ時には外すこと allow_browser versions: :modern
 
   protected
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,8 +60,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # DELETE /resource
   def destroy
     current_user.destroy
-    flash[:notice] = "ユーザーを削除しました"
-    redirect_to :root
+    sign_out current_user
+    flash[:notice] = "すいみんにっしをご利用いただきありがとうございました。"
+    redirect_to new_user_session_path, status: :see_other
   end
 
   # GET /resource/cancel

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -2,15 +2,15 @@ class SleepLogForm
   # ActiveModelを使ってフォームバリデーション
   include ActiveModel::Model # 通常のモデルと同じくバリデーションを使えるように
   include ActiveModel::Attributes # attr_accessorと同じように属性が使える
+  include ActiveModel::Validations::Callbacks # before_validation用
 
   # パラメータの読み書きを許可する。指定の属性に変換してくれる。デフォルト値も設定可能。各モデルで扱いたいカラム名をインスタンス変数名としている。
-  # FIXME: 最早型指定する理由がtime型->datetime型への変更により無くなったので、attr_accessorで良くね？
   attribute :user_id, :integer
   attribute :sleep_date, :date # 気持ちを込めたDate属性
-  attribute :go_to_bed_at, :datetime # 元々DateTime属性だが、日時加工用
-  attribute :fell_asleep_at, :datetime
-  attribute :woke_up_at, :datetime
-  attribute :leave_bed_at, :datetime
+  attribute :go_to_bed_at, :time # 元々DateTime属性だが、日時加工用
+  attribute :fell_asleep_at, :time
+  attribute :woke_up_at, :time
+  attribute :leave_bed_at, :time
 
   # 子モデルで扱いたいカラムの属性
   # attr_accessor :awakening, :napping_time, :comment
@@ -32,65 +32,47 @@ class SleepLogForm
   validates :napping_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 1440 }
   validates :comment, length: { maximum: 42 }
 
+  # バリデーション前に時刻の論理的な日付調整を行う
+  #before_validation :adjust_datetimes_for_sleep_cycle
+
   # 純粋なバリデーション祭の直後にカスタムバリデート祭開催
-  validate :validate_sleep_times_order # 日時の論理性
-  validate :validate_sleep_times_range # 日付の論理性
+  #validate :validate_sleep_times_order # 日時の論理性
+  #validate :validate_sleep_times_range # 日付の論理性
 
   # initializeをオーバーライドできない fetch_valueとは:Rubyのメソッド→initializeオーバーライドしてはいかん→fetchにattributes
   def initialize(attributes = nil, sleep_log: SleepLog.new)
-    # binding.pry
     # sleep_logモデルは一旦nilにして、findさせたものを入れるか作る
     pp "initializeメソッド始動"
-    # binding.pry
     @sleep_log_form = sleep_log
     attributes ||= default_attributes
     super(attributes) # 上で設定した属性などの設定を適用 このFormobjectは誰の親からも継承していない
     set_child_models(@sleep_log_form)
-    # self.sleep_date = sleep_date
-    # その日付のレコードが見つからなければ新規作成して日付をぶちこむ
-    # @sleep_log_form = sleep_log || user.sleep_logs.find_or_initialize_by(sleep_date: sleep_date, user_id: @user)
-    # 親戻ると子モデルが同時に存在する場合は子モデルの値を入れる、そうでなければ子モデルを作成
-    # @sleep_log_form.sleep_date ||= self.sleep_date # sleep_dateがnilの場合、明示的にセットする
-    # 親モデルと子モデルが同時に存在する場合は子モデルの値を入れる、そうでなければ子モデルを作成
-    # @sleep_log_form.awakening ||= Awakening.new # TODO: もしかしたらawakenings_countとかかも
-    # @sleep_log_form.napping_time ||= NappingTime.new
-    # @sleep_log_form.comment ||= Comment.new
-    #  pp @sleep_log_form.sleep_date # 'Sat, 01 Mar 2025'という値が返る
-    # @sleep_log_form.sleep_date = sleep_date # 送られてきた日付を入れる
-    # @sleep_log_form.user_id = user_id # saveの段階で入れられないか？
-    # pp "子モデルをビルド"
-    # pp @sleep_log_form.inspect # '#<SleepLog id: nil, user_id: 1, go_to_bed_at: nil, fell_asleep_at: nil, woke_up_at: nil, leave_bed_at: nil, created_at: nil, updated_at: nil, sleep_date: "2025-03-01">'
-    # pp @sleep_log_form.awakening.inspect # '<#Awakening id: nil, sleep_log_id: nil, awakenings_count: nil, created_at: nil, updated_at: nil>'
-
-
-    # self.attributes = @sleep_log_form.attributes if @sleep_log_form.persisted? # ぶち込み済みなので不要？
-
     # @sleep_log_form # メソッドでは最終行のインスタンスがreturnされる仕組み TODO: 詰まったら再チェック
   end
 
   def save
     pp "saveメソッド"
-    # バリデーションに引っかかる場合は以降の処理にせずfalseをコントローラーに返す
     return false unless valid? # 上記のvalidatesをチェック
-
-
     # 結局saveは一度しかしてないのでいらないのではActiveRecord::Base.transaction do
     # 新規セーブまたは更新セーブを開始する(ユーザーidと睡眠日から検索する)
     sleep_log = SleepLog.find_or_initialize_by(user_id: user_id, sleep_date: sleep_date)
-
-    # 親モデルカラムにフォームの値をセット
-    sleep_log.go_to_bed_at = go_to_bed_at
-    sleep_log.fell_asleep_at = fell_asleep_at
-    sleep_log.woke_up_at = woke_up_at
-    sleep_log.leave_bed_at = leave_bed_at
     # Time型をDateTime型に変換
-    # %i[go_to_bed_at fell_asleep_at woke_up_at leave_bed_at].each do |column|
-    #   time_value = attributes[column.to_s] # Formオブジェクトで同じカラム名がついているattributesさんを呼び出し
-    #   sleep_log[column] = convert_to_datetime(sleep_date, time_value) if time_value.present?
-    # end
+    %i[go_to_bed_at fell_asleep_at woke_up_at leave_bed_at].each do |column|
+      time_value = attributes[column.to_s] # Formオブジェクトで同じカラム名がついているattributesさんを呼び出し
+      sleep_log[column] = convert_to_datetime(sleep_date, time_value) if time_value.present?
+    end
 
     # 起床日が就床・就寝時刻よりも前にならないように変換
-    # adjust_datetime_order(sleep_log)
+    adjust_datetime_order(sleep_log)
+    # バリデーションに引っかかる場合は以降の処理にせずfalseをコントローラーに返す
+
+
+
+    # # 親モデルカラムにフォームの値をセット
+    # sleep_log.go_to_bed_at = go_to_bed_at
+    # sleep_log.fell_asleep_at = fell_asleep_at
+    # sleep_log.woke_up_at = woke_up_at
+    # sleep_log.leave_bed_at = leave_bed_at
 
     # Formオブジェクトの値をビルドしたsleep_logの子モデルにセット
     set_child_models(sleep_log)
@@ -112,7 +94,7 @@ class SleepLogForm
   private
 
   def convert_to_datetime(sleep_date, time_value)
-    return nil if time_value.blank? # もし時間入力がなければnilで登録
+    return if time_value.blank? # もし時間入力がなければ返す
     "#{sleep_date} #{time_value}".in_time_zone # "YYYY-MM-DD + time_value: HH:MM" をローカル時間で保存
   end
 
@@ -120,7 +102,6 @@ class SleepLogForm
   def adjust_datetime_order(sleep_log)
     if sleep_log.woke_up_at.present?
       %i[go_to_bed_at fell_asleep_at].each do |fix_date|
-        next unless sleep_log[fix_date].present? # 未入力の場合は次の処理へ
         if sleep_log[fix_date] > sleep_log.woke_up_at
           sleep_log[fix_date] -= 1.day # 前夜就寝とする
         end
@@ -158,13 +139,12 @@ class SleepLogForm
       awakenings_count: @sleep_log_form.awakening&.awakenings_count || 0,
       napping_time: @sleep_log_form.napping_time&.napping_time || 0,
       comment: @sleep_log_form.comment&.comment || ""
-
     }
   end
 
   # カスタムバリデータ祭
   def validate_sleep_times_order
-    return if go_to_bed_at.blank? || fell_asleep_at.blank? || woke_up_at.blank? || leave_bed_at.blank?
+    return false if go_to_bed_at.blank? || fell_asleep_at.blank? || woke_up_at.blank? || leave_bed_at.blank?
     # go_to_bed_atがfell_asleep_atより後の日時だった場合
     if go_to_bed_at > fell_asleep_at
       errors.add(:go_to_bed_at, "は昨夜寝た時刻より前の時刻にしてください")

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -59,7 +59,8 @@ class SleepLogForm
     # Time型をDateTime型に変換
     %i[go_to_bed_at fell_asleep_at woke_up_at leave_bed_at].each do |column|
       time_value = attributes[column.to_s] # Formオブジェクトで同じカラム名がついているattributesさんを呼び出し
-      sleep_log[column] = convert_to_datetime(sleep_date, time_value) if time_value.present?
+      # もしTime入力があればDateTime型に変換、未入力であれば明示的にnilを代入することで、edit画面で未入力した際にバリデーションエラーを発生させる
+      sleep_log[column] = time_value.present? ? convert_to_datetime(sleep_date, time_value) : nil
     end
 
     # 起床日が就床・就寝時刻よりも前にならないように変換
@@ -99,6 +100,7 @@ class SleepLogForm
   # 覚醒時刻が就床時刻・入眠時刻よりも後にならないよう修正
   def adjust_datetime_order(sleep_log)
     pp "日時修正"
+    # ここガチガチに固めておかないと、カスタムバリデータまで貫通してしまう
     return unless sleep_log.go_to_bed_at.present? &&
                 sleep_log.fell_asleep_at.present? &&
                 sleep_log.woke_up_at.present? &&
@@ -109,6 +111,7 @@ class SleepLogForm
       end
     end
 
+    # DateTime型に加工した際に2000-01-01になっているので、改めて教え込ませる
     self.go_to_bed_at = sleep_log.go_to_bed_at
     self.fell_asleep_at = sleep_log.fell_asleep_at
     self.woke_up_at = sleep_log.woke_up_at

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -164,6 +164,7 @@ class SleepLogForm
 
   # カスタムバリデータ祭
   def validate_sleep_times_order
+    return if go_to_bed_at.blank? || fell_asleep_at.blank? || woke_up_at.blank? || leave_bed_at.blank?
     # go_to_bed_atがfell_asleep_atより後の日時だった場合
     if go_to_bed_at > fell_asleep_at
       errors.add(:go_to_bed_at, "は昨夜寝た時刻より前の時刻にしてください")
@@ -186,6 +187,7 @@ class SleepLogForm
   end
 
   def validate_sleep_times_range
+    return if go_to_bed_at.blank? || fell_asleep_at.blank? || woke_up_at.blank? || leave_bed_at.blank?
     if go_to_bed_at.present? && ![ sleep_date, sleep_date - 1.day ].include?(go_to_bed_at.to_date)
       errors.add(:go_to_bed_at, "寝すぎです。日付を見直してください")
     end

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -37,7 +37,7 @@ class SleepLogForm
 
   # 純粋なバリデーション祭の直後にカスタムバリデート祭開催
   validate :validate_sleep_times_order # 日時の論理性
-  #validate :validate_sleep_times_range # 日付の論理性
+  # validate :validate_sleep_times_range # 日付の論理性
 
   # initializeをオーバーライドできない fetch_valueとは:Rubyのメソッド→initializeオーバーライドしてはいかん→fetchにattributes
   def initialize(attributes = nil, sleep_log: SleepLog.new)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,9 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash' %>
-    <%= yield %>
+    <div class="py-20"> <!-- ヘッダーの高さがh-20 -->
+      <%= yield %>
+    </div>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180">
     <link rel="manifest" href="/site.webmanifest">
-ß
+
     <!-- GoggleFont -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -31,7 +31,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="text-neutral kiwi-maru-regular base-100 w-screen print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
+  <body class="kiwi-maru-regular w-screen bg-cover text-neutral base-100 print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="kiwi-maru-regular overflow-x-hidden w-screen bg-cover text-neutral base-100 print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
+  <body class="kiwi-maru-regular overflow-x-hidden w-screen bg-cover text- base-100 print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Kiwi+Maru&display=swap" rel="stylesheet">
 
     <!-- Icon -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=edit_square" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 
     <!-- Turbo使用時、アセットが更新されたときに再ロードする -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="kiwi-maru-regular w-screen bg-cover text-neutral base-100 print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
+  <body class="kiwi-maru-regular overflow-x-hidden w-screen bg-cover text-neutral base-100 print:flex print:items-center print:justify-center print:min-h-screen print:bg-transparent"> <!-- 印刷時中央寄せ&まじない程度に印刷時背景透明 -->
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,14 +1,13 @@
-<header class="print:hidden fixed top-0 left-0 h-20 w-full z-50 p-4 content-center bg-cover bg-secondary">
-<!-- ナビゲーションバー -->
-  <nav class="flex items-center justify-between">
-    <div class="flex items-center flex-shrink-0">
-      <%= link_to "すいみんにっし", root_path, class: "text-2xl drop-shadow-md text-primary" %>
+<header class="navbar absolute h-20 w-full z-50 content-center shadow-md bg-secondary print:hidden">
+  <div class="flex items-center justify-between w-full p-6">
+    <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
+      <%= link_to "すいみんにっし", root_path %>
     </div>
-    <div class="flex space-x-6">
-      <%= link_to "使いかた", "#", class: "text-neutral hover:text-primary" %>
-      <%= link_to "記録する", root_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "新規登録", new_user_registration_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "ログイン", new_user_session_path, class: "text-neutral hover:text-primary" %>
+    <div class="space-x-4">
+      <%= link_to "使いかた", "#", class: "hover:text-primary" %>
+      <%= link_to "記録する", root_path, class: "hover:text-primary" %>
+      <%= link_to "新規登録", new_user_registration_path, class: "hover:text-primary" %>
+      <%= link_to "ログイン", new_user_session_path, method: :delete, class: "hover:text-primary" %>
     </div>
-  </nav>
+  </div>
 </header>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,9 +1,9 @@
 <header class="print:hidden fixed top-0 h-20 w-full z-50 content-center shadow-md bg-secondary">
   <div class="flex items-center justify-between w-full px-6">
-    <div class="text-xl md:text-3xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
+    <div class="text-base ms:text-xl md:text-3xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
       <%= link_to "すいみんにっし", root_path %>
     </div>
-    <div class="space-x-4">
+    <div class="space-x-1 md:space-x-4 text-xs ms:text-sm md:text-base">
       <%= link_to "使いかた", "#", class: "hover:text-primary" %>
       <%= link_to "記録する", root_path, class: "hover:text-primary" %>
       <%= link_to "新規登録", new_user_registration_path, class: "hover:text-primary" %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header class="print:hidden fixed top-0 h-20 w-full z-50 content-center shadow-md bg-secondary">
-  <div class="flex items-center justify-between w-full p-6">
-    <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
+  <div class="flex items-center justify-between w-full px-6">
+    <div class="text-xl md:text-3xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
       <%= link_to "すいみんにっし", root_path %>
     </div>
     <div class="space-x-4">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<header class="navbar absolute h-20 w-full z-50 content-center shadow-md bg-secondary print:hidden">
+<header class="print:hidden fixed top-0 h-20 w-full z-50 content-center shadow-md bg-secondary">
   <div class="flex items-center justify-between w-full p-6">
     <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
       <%= link_to "すいみんにっし", root_path %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,7 +1,7 @@
 <!-- フラッシュメッセージ表示用-->
 <div id="flash-messages" class="flex items-center fixed top-32 z-[9999] pointer-events-none space-y-2">
   <% if notice %>
-    <div class="print:hidden notice success flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-tr-xl rounded-br-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden notice success flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-e-xl text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
          data-flash-duration-value="2500"> <%# 2.5秒 %>
       <%= notice %>
@@ -9,7 +9,7 @@
   <% end %>
 
   <% if alert %>
-    <div class="print:hidden alert error flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-tr-xl rounded-br-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden alert error flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-e-xl text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
          data-flash-duration-value="4000"> <%# 4.0秒 %>
       <%= alert %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,7 +1,7 @@
 <!-- フラッシュメッセージ表示用-->
 <div id="flash-messages" class="flex items-center fixed top-32 z-[9999] pointer-events-none space-y-2">
   <% if notice %>
-    <div class="print:hidden notice success flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-e-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden notice success flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-e-xl rounded-s-none text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
          data-flash-duration-value="2500"> <%# 2.5秒 %>
       <%= notice %>
@@ -9,7 +9,7 @@
   <% end %>
 
   <% if alert %>
-    <div class="print:hidden alert error flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-e-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden alert error flex justify-center items-center text-center p-4 h-16 w-auto bg-error rounded-e-xl rounded-s-none text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
          data-flash-duration-value="4000"> <%# 4.0秒 %>
       <%= alert %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,7 +1,7 @@
-<!-- フラッシュメッセージ表示用(いづれ、success用のフラッシュメッセージも作りたい) -->
-<div id="flash-messages" class="fixed top-4 left-0 w-full z-[9999] p-4 pointer-events-none flex flex-col items-center space-y-2">
+<!-- フラッシュメッセージ表示用-->
+<div id="flash-messages" class="flex items-center fixed top-32 z-[9999] pointer-events-none space-y-2">
   <% if notice %>
-    <div class="print:hidden notice success flex justify-center items-center text-center h-16 w-[90%] bg-success rounded-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden notice success flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-tr-xl rounded-br-xl text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
          data-flash-duration-value="2500"> <%# 2.5秒 %>
       <%= notice %>
@@ -9,9 +9,9 @@
   <% end %>
 
   <% if alert %>
-    <div class="print:hidden alert error flex justify-center items-center h-16 w-[90%] bg-error rounded-xl text-primary pointer-events-auto shadow-lg"
+    <div class="print:hidden alert error flex justify-center items-center text-center p-4 h-16 w-auto bg-success rounded-tr-xl rounded-br-xl text-primary pointer-events-auto shadow-lg"
          data-controller="flash"
-         data-flash-duration-value="4500"> <%# 例えば4.5秒表示したい場合 %>
+         data-flash-duration-value="4000"> <%# 4.0秒 %>
       <%= alert %>
     </div>
   <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="print:hidden fixed bottom-0 left-0 h-20 w-full z-50 p-4 content-center bg-cover bg-secondary">
+<footer class="print:hidden absolute bottom-0 left-0 h-20 w-full z-50 p-4 content-center bg-cover bg-secondary">
   <!-- 全体のフレックスレイアウト -->
   <div class="flex justify-between items-center w-full">
     <nav class="flex space-x-4">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,30 +1,29 @@
-<footer class="print:hidden absolute bottom-0 left-0 h-20 w-full z-50 p-4 content-center bg-cover bg-secondary">
-  <!-- 全体のフレックスレイアウト -->
-  <div class="flex justify-between items-center w-full">
+<footer class="print:hidden fixed bottom-0 h-20 w-full z-50 content-center bg-secondary">
+  <div class="flex items-center justify-between w-full px-6">
     <nav class="flex space-x-4">
-      <%= link_to "お問い合わせ", footers_contact_form_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "利用規約", footers_terms_of_service_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "プライバシーポリシー", footers_privacy_policy_path, class:"text-neutral hover:text-primary" %>
+      <%= link_to "お問い合わせ", footers_contact_form_path, class: "hover:text-primary" %>
+      <%= link_to "利用規約", footers_terms_of_service_path, class: "hover:text-primary" %>
+      <%= link_to "プライバシーポリシー", footers_privacy_policy_path, class:"hover:text-primary" %>
     </nav>
-    <div class="flex flex-col justify-end items-center space-y-1">
+    <div class="flex flex-col justify-center items-center space-y-1">
       <!-- アイコン行 -->
       <div class="flex items-center space-x-4">
         <!-- GitHubアイコン -->
         <a href="https://github.com/m-porun/SleepLogger">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4 text-neutral hover:text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 text-neutral hover:text-primary fill-current">
             <path d="M12.5.75C6.146.75 1 5.896 1 12.25c0 5.089 3.292 9.387 7.863 10.91.575.101.79-.244.79-.546 0-.273-.014-1.178-.014-2.142-2.889.532-3.636-.704-3.866-1.35-.13-.331-.69-1.352-1.18-1.625-.402-.216-.977-.748-.014-.762.906-.014 1.553.834 1.769 1.179 1.035 1.74 2.688 1.25 3.349.948.1-.747.402-1.25.733-1.538-2.559-.287-5.232-1.279-5.232-5.678 0-1.25.445-2.285 1.178-3.09-.115-.288-.517-1.467.115-3.048 0 0 .963-.302 3.163 1.179.92-.259 1.897-.388 2.875-.388.977 0 1.955.13 2.875.388 2.2-1.495 3.162-1.179 3.162-1.179.633 1.581.23 2.76.115 3.048.733.805 1.179 1.825 1.179 3.09 0 4.413-2.688 5.39-5.247 5.678.417.36.776 1.05.776 2.128 0 1.538-.014 2.774-.014 3.162 0 .302.216.662.79.547C20.709 21.637 24 17.324 24 12.25 24 5.896 18.854.75 12.5.75Z" />
           </svg>
         </a>
         <!-- Xアイコン -->
         <a href="https://x.com/miyamagear">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1227" class="w-4 h-4 text-neutral hover:text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1227" class="w-5 h-5 text-neutral hover:text-primary fill-current">
             <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" />
           </svg>
         </a>
       </div>
 
       <!-- コピーライト -->
-      <div class="flex justify-between items-center w-full mt-2">
+      <div class="mt-2">
         <p>© <%= Time.new.year %> SleepLogger</p>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -23,7 +23,7 @@
       </div>
 
       <!-- コピーライト -->
-      <div class="mt-2">
+      <div>
         <p>© <%= Time.new.year %> SleepLogger</p>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,29 +1,29 @@
-<footer class="print:hidden fixed bottom-0 h-20 w-full z-50 content-center bg-secondary">
-  <div class="flex items-center justify-between w-full px-6">
-    <nav class="flex space-x-4">
+<footer class="print:hidden fixed bottom-0 h-20 w-full z-50 content-center text-sm md:text-base bg-secondary">
+  <div class="flex items-center justify-between w-full px-4 ms:px-6 text-xs ms:text-sm md:text-base">
+    <nav class="flex space-x-1 sm:space-x-4">
       <%= link_to "お問い合わせ", footers_contact_form_path, class: "hover:text-primary" %>
       <%= link_to "利用規約", footers_terms_of_service_path, class: "hover:text-primary" %>
       <%= link_to "プライバシーポリシー", footers_privacy_policy_path, class:"hover:text-primary" %>
     </nav>
-    <div class="flex flex-col justify-center items-center space-y-1">
+    <div class="flex flex-col justify-center items-end space-y-1">
       <!-- アイコン行 -->
       <div class="flex items-center space-x-4">
         <!-- GitHubアイコン -->
         <a href="https://github.com/m-porun/SleepLogger">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 text-neutral hover:text-primary fill-current">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 sm:w-6 h-4 sm:h-6 text-neutral hover:text-primary fill-current">
             <path d="M12.5.75C6.146.75 1 5.896 1 12.25c0 5.089 3.292 9.387 7.863 10.91.575.101.79-.244.79-.546 0-.273-.014-1.178-.014-2.142-2.889.532-3.636-.704-3.866-1.35-.13-.331-.69-1.352-1.18-1.625-.402-.216-.977-.748-.014-.762.906-.014 1.553.834 1.769 1.179 1.035 1.74 2.688 1.25 3.349.948.1-.747.402-1.25.733-1.538-2.559-.287-5.232-1.279-5.232-5.678 0-1.25.445-2.285 1.178-3.09-.115-.288-.517-1.467.115-3.048 0 0 .963-.302 3.163 1.179.92-.259 1.897-.388 2.875-.388.977 0 1.955.13 2.875.388 2.2-1.495 3.162-1.179 3.162-1.179.633 1.581.23 2.76.115 3.048.733.805 1.179 1.825 1.179 3.09 0 4.413-2.688 5.39-5.247 5.678.417.36.776 1.05.776 2.128 0 1.538-.014 2.774-.014 3.162 0 .302.216.662.79.547C20.709 21.637 24 17.324 24 12.25 24 5.896 18.854.75 12.5.75Z" />
           </svg>
         </a>
         <!-- Xアイコン -->
         <a href="https://x.com/miyamagear">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1227" class="w-5 h-5 text-neutral hover:text-primary fill-current">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1227" class="w-3 sm:w-5 h-3 sm:h-5 text-neutral hover:text-primary fill-current">
             <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" />
           </svg>
         </a>
       </div>
 
       <!-- コピーライト -->
-      <div>
+      <div class="text-xs sm:text-sm md:text-base text-right w-full">
         <p>© <%= Time.new.year %> SleepLogger</p>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,14 +1,13 @@
-<header class="print:hidden fixed top-0 left-0 h-20 w-full z-50 p-4 content-center bg-cover bg-secondary">
-<!-- ナビゲーションバー -->
-  <nav class="flex items-center justify-between">
-    <div class="flex items-center flex-shrink-0">
-      <%= link_to "すいみんにっし", root_path, class: "text-2xl drop-shadow-md text-primary" %>
+</header><header class="navbar absolute h-20 w-full z-50 content-center shadow-md bg-secondary print:hidden">
+  <div class="flex items-center justify-between w-full p-6">
+    <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
+      <%= link_to "すいみんにっし", root_path %>
     </div>
-    <div class="flex space-x-6">
-      <%= link_to "使いかた", "#", class: "text-neutral hover:text-primary" %>
-      <%= link_to "記録する", root_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "設定", users_edit_profile_path, class: "text-neutral hover:text-primary" %>
-      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-neutral hover:text-primary" %>
+    <div class="space-x-4">
+      <%= link_to "使いかた", "#", class: "hover:text-primary" %>
+      <%= link_to "記録する", root_path, class: "hover:text-primary" %>
+      <%= link_to "設定", users_edit_profile_path, class: "hover:text-primary" %>
+      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "hover:text-primary" %>
     </div>
-  </nav>
+  </div>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
 <header class="print:hidden fixed top-0 h-20 w-full z-50 content-center shadow-md bg-secondary">
-  <div class="flex items-center justify-between w-full p-6">
-    <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
+  <div class="flex items-center justify-between w-full px-4 ms:px-6">
+    <div class="text-base ms:text-xl md:text-3xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
       <%= link_to "すいみんにっし", root_path %>
     </div>
-    <div class="space-x-4">
+    <div class="space-x-1 md:space-x-4 text-xs ms:text-sm md:text-base">
       <%= link_to "使いかた", "#", class: "hover:text-primary" %>
       <%= link_to "記録する", root_path, class: "hover:text-primary" %>
       <%= link_to "設定", users_edit_profile_path, class: "hover:text-primary" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-</header><header class="navbar absolute h-20 w-full z-50 content-center shadow-md bg-secondary print:hidden">
+<header class="print:hidden fixed top-0 h-20 w-full z-50 content-center shadow-md bg-secondary">
   <div class="flex items-center justify-between w-full p-6">
     <div class="text-2xl text-primary [text-shadow:_0_1px_0_var(--tw-shadow-color)] shadow-accent">
       <%= link_to "すいみんにっし", root_path %>

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -25,7 +25,7 @@
         <div class="w-full md:w-1/2 space-y-4">
           <div>
             <%= f.label :go_to_bed_at, "昨夜布団に入った時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.datetime_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
+            <%= f.time_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
             <% if f.object.errors[:go_to_bed_at].any? %>
               <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
             <% end %>
@@ -33,7 +33,7 @@
 
           <div>
             <%= f.label :fell_asleep_at, "昨夜寝た時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.datetime_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
+            <%= f.time_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
             <% if f.object.errors[:fell_asleep_at].any? %>
               <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
             <% end %>
@@ -43,7 +43,7 @@
         <div class="w-full md:w-1/2 space-y-4">
           <div>
             <%= f.label :woke_up_at, "今朝目覚めた時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.datetime_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
+            <%= f.time_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
             <% if f.object.errors[:woke_up_at].any? %>
               <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
             <% end %>
@@ -51,7 +51,7 @@
 
           <div>
             <%= f.label :leave_bed_at, "今朝布団から出た時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.datetime_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
+            <%= f.time_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
             <% if f.object.errors[:leave_bed_at].any? %>
               <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
             <% end %>

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -12,8 +12,8 @@
       </div>
     <% end %>
 
-    <div class="space-y-4">
-      <div>
+    <div class="flex flex-col space-y-4">
+      <div class="mb-4">
         <%= f.label :sleep_date, '起きた日付', class: "block text-sm font-medium mb-1" %>
         <% display_date = (f.object.sleep_date.presence || params[:sleep_date]) %>
         <% display_date = display_date.to_date if display_date.is_a?(String) %>
@@ -21,41 +21,37 @@
         <%= f.hidden_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true, class: "input input-ghost" %>
       </div>
 
-      <div class="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
-        <div class="w-full md:w-1/2 space-y-4">
-          <div>
-            <%= f.label :go_to_bed_at, "昨夜布団に入った時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.time_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
-            <% if f.object.errors[:go_to_bed_at].any? %>
-              <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
-            <% end %>
-          </div>
-
-          <div>
-            <%= f.label :fell_asleep_at, "昨夜寝た時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.time_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
-            <% if f.object.errors[:fell_asleep_at].any? %>
-              <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
-            <% end %>
-          </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 md:gap-x-8 md:gap-y-4">
+        <div>
+          <%= f.label :go_to_bed_at, "昨夜布団に入った時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.time_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
+          <% if f.object.errors[:go_to_bed_at].any? %>
+            <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
+          <% end %>
         </div>
 
-        <div class="w-full md:w-1/2 space-y-4">
-          <div>
-            <%= f.label :woke_up_at, "今朝目覚めた時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.time_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
-            <% if f.object.errors[:woke_up_at].any? %>
-              <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
-            <% end %>
-          </div>
+        <div>
+          <%= f.label :fell_asleep_at, "昨夜寝た時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.time_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
+          <% if f.object.errors[:fell_asleep_at].any? %>
+            <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
+          <% end %>
+        </div>
 
-          <div>
-            <%= f.label :leave_bed_at, "今朝布団から出た時刻", class: "block text-sm font-medium mb-1" %>
-            <%= f.time_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
-            <% if f.object.errors[:leave_bed_at].any? %>
-              <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
-            <% end %>
-          </div>
+        <div>
+          <%= f.label :woke_up_at, "今朝目覚めた時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.time_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
+          <% if f.object.errors[:woke_up_at].any? %>
+            <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
+          <% end %>
+        </div>
+
+        <div>
+          <%= f.label :leave_bed_at, "今朝布団から出た時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.time_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
+          <% if f.object.errors[:leave_bed_at].any? %>
+            <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -1,8 +1,7 @@
 <!-- new, editファイルの中身 -->
-<div class="flex justify-center items-center">
   <!-- new_record?メソッドを使って、newかeditかでURLとmethodを切り替える -->
-  <%= form_with(model: sleep_log_form, url: sleep_log_form.new_record? ? sleep_logs_path : sleep_log_path(sleep_log_form.id), method: sleep_log_form.new_record? ? :post : :patch) do |f| %>
-    <!-- 全体エラーの表示ゾーン -->
+<div class="flex justify-center items-center py-6">
+  <%= form_with(model: sleep_log_form, url: sleep_log_form.new_record? ? sleep_logs_path : sleep_log_path(sleep_log_form.id), method: sleep_log_form.new_record? ? :post : :patch, class: "w-full max-w-lg mx-auto") do |f| %>
     <% if sleep_log_form.errors.any? %>
       <div class="flex justify-center items-center text-center mb-4 text-error font-bold">
         <ul>
@@ -13,74 +12,85 @@
       </div>
     <% end %>
 
-    <!-- フォームの中身 -->
-    <div>
-        <%= f.label :sleep_date, '起きた日付' %>
+    <div class="space-y-4">
+      <div>
+        <%= f.label :sleep_date, '起きた日付', class: "block text-sm font-medium mb-1" %>
         <% display_date = (f.object.sleep_date.presence || params[:sleep_date]) %>
-        <% display_date = display_date.to_date if display_date.is_a?(String) %> <!-- paramsのパラメーターをString型に変換 -->
-        <p><%= display_date.strftime('%Y年%-m月%-d日') if display_date.present? %></p>
-        <!-- 絶対に入力させたくないマン -->
-        <%= f.hidden_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true, class: "input input-ghost" %> <!-- f.objectに値があれば日付を、なければ探す -->
+        <% display_date = display_date.to_date if display_date.is_a?(String) %>
+        <p class="text-base font-semibold "><%= display_date.strftime('%Y年%-m月%-d日') if display_date.present? %></p>
+        <%= f.hidden_field :sleep_date, value: f.object.sleep_date.presence || params[:sleep_date], readonly: true, class: "input input-ghost" %>
+      </div>
+
+      <div class="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
+        <div class="w-full md:w-1/2 space-y-4">
+          <div>
+            <%= f.label :go_to_bed_at, "昨夜布団に入った時刻", class: "block text-sm font-medium mb-1" %>
+            <%= f.datetime_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
+            <% if f.object.errors[:go_to_bed_at].any? %>
+              <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.label :fell_asleep_at, "昨夜寝た時刻", class: "block text-sm font-medium mb-1" %>
+            <%= f.datetime_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
+            <% if f.object.errors[:fell_asleep_at].any? %>
+              <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="w-full md:w-1/2 space-y-4">
+          <div>
+            <%= f.label :woke_up_at, "今朝目覚めた時刻", class: "block text-sm font-medium mb-1" %>
+            <%= f.datetime_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
+            <% if f.object.errors[:woke_up_at].any? %>
+              <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.label :leave_bed_at, "今朝布団から出た時刻", class: "block text-sm font-medium mb-1" %>
+            <%= f.datetime_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
+            <% if f.object.errors[:leave_bed_at].any? %>
+              <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <%= f.label :awakenings_count, "中途覚醒（回数）", class: "block text-sm font-medium mb-1" %>
+        <%= f.number_field :awakenings_count, min: 0, class: "input input-bordered w-full bg-primary" %>
+        <% if f.object.errors[:awakenings_count].any? %>
+          <p class="text-error text-xs mt-1"><%= f.object.errors[:awakenings_count].join(", ") %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :napping_time, "昼寝時間（分）", class: "block text-sm font-medium mb-1" %>
+        <%= f.number_field :napping_time, min: 0, class: "input input-bordered w-full bg-primary " %>
+        <% if f.object.errors[:napping_time].any? %>
+          <p class="text-error text-xs mt-1"><%= f.object.errors[:napping_time].join(", ") %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :comment, "備考(42文字まで)", class: "block text-sm font-medium mb-1" %>
+        <%= f.text_area :comment, max: 42,
+                          class: "textarea textarea-bordered w-full bg-primary indent-1 text-sm resize-y",
+                          placeholder:"昨夜はよく眠れましたか？　薬は飲みましたか？",
+                          data: { controller: "textarea-autoresize", action: "input->textarea-autoresize#resize" } %>
+        <% if f.object.errors[:comment].any? %>
+          <p class="text-error text-xs mt-1"><%= f.object.errors[:comment].join(", ") %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.submit sleep_log_form.new_record? ? "登録" : "更新", class: "flex w-full rounded rounded-md bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4"%>
+      </div>
     </div>
 
-    <div>
-      <%= f.label :go_to_bed_at, "昨夜布団に入った時刻" %>
-      <%= f.datetime_field :go_to_bed_at, class: "input input-bordered bg-primary" %>
-      <% if f.object.errors[:go_to_bed_at].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
-      <% end %>
-    </div>
 
-    <div>
-      <%= f.label :fell_asleep_at, "昨夜寝た時刻" %>
-      <%= f.datetime_field :fell_asleep_at, class: "input input-bordered bg-primary" %>
-      <% if f.object.errors[:fell_asleep_at].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :woke_up_at, "今朝目覚めた時刻" %>
-      <%= f.datetime_field :woke_up_at, class: "input input-bordered bg-primary" %>
-      <% if f.object.errors[:woke_up_at].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :leave_bed_at, "今朝布団から出た時刻" %>
-      <%= f.datetime_field :leave_bed_at, class: "input input-bordered bg-primary" %>
-      <% if f.object.errors[:leave_bed_at].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :awakenings_count, "中途覚醒（回数）" %>
-      <%= f.number_field :awakenings_count, min: 0 %> <!-- デフォルトで0が入力されている -->
-      <% if f.object.errors[:awakenings_count].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:awakenings_count].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :napping_time, "昼寝時間（分）" %>
-      <%= f.number_field :napping_time, min: 0 %> <!-- デフォルトで0が入力されている -->
-      <% if f.object.errors[:napping_time].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:napping_time].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :comment, "備考(42文字まで)" %>
-      <%= f.text_area :comment, max: 42 %>
-      <% if f.object.errors[:comment].any? %>
-        <p class="text-error text-xs mt-1"><%= f.object.errors[:comment].join(", ") %></p>
-      <% end %>
-    </div>
-
-    <div class="flex justify-end">
-      <%= f.submit sleep_log_form.new_record? ? "登録" : "更新", class: "bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4 rounded"%>
-    </div>
   <% end %>
 </div>

--- a/app/views/sleep_logs/_logs_table.html.erb
+++ b/app/views/sleep_logs/_logs_table.html.erb
@@ -9,8 +9,8 @@
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">覚醒時刻</th>
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">起床時刻</th>
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[15%] md:w-24 print:w-20">睡眠時間</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base">中途覚醒(回)</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base">昼寝時間(分)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base print:text-[8px]">中途覚醒(回)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base print:text-[8px]">昼寝時間(分)</th>
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-1/3 max-w-[33%] print:w-56 print:max-w-1/3 hidden md:table-cell">備考</th>
           <!-- 編集ボタンのみプリントしない -->
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[9%] md:w-8 print:hidden">編集</th>

--- a/app/views/sleep_logs/_logs_table.html.erb
+++ b/app/views/sleep_logs/_logs_table.html.erb
@@ -1,71 +1,71 @@
-<div id="sleep-logs-table">
-    <table class="table-fixed w-full text-center text-sm text-neutral print:leading-none print:py-[15px]">
+<div id="sleep-logs-table" class="relative overflow-x-auto overflow-y-auto h-[600px] md:h-auto print:h-auto print:overflow-visible">
+    <table class="table-fixed w-full text-center text-[12px] md:text-base print:text-sm print:leading-none print:py-[15px]">
       <thead>
-        <tr class="print:text-[12px]">
-          <th class="w-8 border border-secondary bg-primary print:w-8">日</th>
-          <th class="w-8 border border-secondary bg-primary print:w-8">曜日</th>
-          <th class="w-16 border border-secondary bg-primary print:w-14">就床時刻</th>
-          <th class="w-16 border border-secondary bg-primary print:w-14">就寝時刻</th>
-          <th class="w-16 border border-secondary bg-primary print:w-14">覚醒時刻</th>
-          <th class="w-16 border border-secondary bg-primary print:w-14">起床時刻</th>
-          <th class="w-24 border border-secondary bg-primary print:w-20">睡眠時間</th>
-          <th class="w-16 border border-secondary bg-primary print:w-8">中途覚醒(回)</th>
-          <th class="w-16 border border-secondary bg-primary print:w-8">昼寝時間(分)</th>
-          <th class="w-1/3 max-w-[33%] border border-secondary bg-primary print:w-56 print:max-w-1/3">備考</th>
+        <tr class="text-[10px] md:text-base print:text-[9px]">
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-4 md:w-8 print:w-8">日</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-4 md:w-8 print:w-8">曜日</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">就床時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">就寝時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">覚醒時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">起床時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-12 md:w-24 print:w-20">睡眠時間</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-16 print:w-8">中途覚醒(回)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-16 print:w-8">昼寝時間(分)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-1/3 max-w-[33%] print:w-56 print:max-w-1/3 hidden md:table-cell">備考</th>
           <!-- 編集ボタンのみプリントしない -->
-          <th class="w-8 print:hidden border border-secondary bg-primary">編集</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-8 print:hidden">編集</th>
         </tr>
       </thead>
 
-  <% @sleep_logs.each do |sleep_log| %> <!-- 月初から月末までの日付を繰り返し表示する -->
-    <tr class="border border-secondary bg-primary">
-      <td class="border border-secondary bg-primary print:py-2"><%= sleep_log.sleep_date.day %></td>
-      <td class="border border-secondary bg-primary"><%= %w[日 月 火 水 木 金 土][sleep_log.sleep_date.wday] %></td>
-      <td class="border border-secondary bg-primary">
-        <%= sleep_log.go_to_bed_at&.strftime('%H:%M') || "--:--" %>
-      </td>
+      <% @sleep_logs.each do |sleep_log| %> <!-- 月初から月末までの日付を繰り返し表示する -->
+        <tr class="border border-secondary bg-primary">
+          <td class="border border-secondary bg-primary py-4 md:py-auto print:py-2"><%= sleep_log.sleep_date.day %></td>
+          <td class="border border-secondary bg-primary"><%= %w[日 月 火 水 木 金 土][sleep_log.sleep_date.wday] %></td>
+          <td class="border border-secondary bg-primary">
+            <%= sleep_log.go_to_bed_at&.strftime('%H:%M') || "--:--" %>
+          </td>
 
-      <td class="border border-secondary bg-primary">
-        <%= sleep_log.fell_asleep_at&.strftime('%H:%M') || "--:--" %>
-      </td>
+          <td class="border border-secondary bg-primary">
+            <%= sleep_log.fell_asleep_at&.strftime('%H:%M') || "--:--" %>
+          </td>
 
-      <td class="border border-secondary bg-primary">
-        <%= sleep_log.woke_up_at&.strftime('%H:%M') || "--:--" %>
-      </td>
+          <td class="border border-secondary bg-primary">
+            <%= sleep_log.woke_up_at&.strftime('%H:%M') || "--:--" %>
+          </td>
 
-      <td class="border border-secondary bg-primary">
-        <%= sleep_log.leave_bed_at&.strftime('%H:%M') || "--:--" %>
-      </td>
+          <td class="border border-secondary bg-primary">
+            <%= sleep_log.leave_bed_at&.strftime('%H:%M') || "--:--" %>
+          </td>
 
-      <td class="border border-secondary bg-primary">
-        <%= calculate_sleep_duration(sleep_log.fell_asleep_at, sleep_log.woke_up_at) || "--:--" %> <!-- 就寝時刻〜覚醒時刻の睡眠時間を計算する -->
-      </td>
+          <td class="border border-secondary bg-primary text-[9px] md:text-base print:text-xs">
+            <%= calculate_sleep_duration(sleep_log.fell_asleep_at, sleep_log.woke_up_at) || "--:--" %> <!-- 就寝時刻〜覚醒時刻の睡眠時間を計算する -->
+          </td>
 
-      <td class="border border-secondary bg-primary">
-        <%= sleep_log.awakening&.awakenings_count || 0 %>
-      </td>
+          <td class="border border-secondary bg-primary">
+            <%= sleep_log.awakening&.awakenings_count || 0 %>
+          </td>
 
-      <td class="border border-secondary bg-primary">
-          <%= sleep_log.napping_time&.napping_time || 0 %>
-      </td>
+          <td class="border border-secondary bg-primary">
+              <%= sleep_log.napping_time&.napping_time || 0 %>
+          </td>
 
-      <td class="p-2 border border-secondary bg-primary print:p-[5px] print:text-[9px]">
-        <%= sleep_log.comment&.comment || '' %>
-      </td>
+          <td class="p-2 border border-secondary bg-primary print:p-[5px] print:text-[9px] hidden md:table-cell">
+            <%= sleep_log.comment&.comment || '' %>
+          </td>
 
-      <td class="print:hidden border border-secondary bg-primary">
-          <% if sleep_log.persisted? %>
-            <button class="btn w-full" onclick="my_modal_3.showModal()">
-              <%= link_to 'edit_square', edit_sleep_log_path(sleep_log), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined inline-flex" %>
-            </button>
-          <% else %>
-            <button class="btn w-full" onclick="my_modal_3.showModal()">
-              <%= link_to 'edit_square', new_sleep_log_path(sleep_date: sleep_log.sleep_date), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined inline-flex" %> <!-- indexで設定した日付一覧から日付を取得 -->
-            </button>
-          <% end %>
-      </td>
-    </tr>
-  <% end %>
+          <td class="print:hidden border border-secondary bg-primary">
+              <% if sleep_log.persisted? %>
+                <button onclick="my_modal_3.showModal()">
+                  <%= link_to 'edit_square', edit_sleep_log_path(sleep_log), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined text-base md:text-2xl hover:text-accent" %>
+                </button>
+              <% else %>
+                <button onclick="my_modal_3.showModal()">
+                  <%= link_to 'edit_square', new_sleep_log_path(sleep_date: sleep_log.sleep_date), data: { turbo_frame: 'sleep_log_frame'}, class: "material-symbols-outlined text-base md:text-2xl hover:text-accent" %> <!-- indexで設定した日付一覧から日付を取得 -->
+                </button>
+              <% end %>
+          </td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 </div>

--- a/app/views/sleep_logs/_logs_table.html.erb
+++ b/app/views/sleep_logs/_logs_table.html.erb
@@ -2,18 +2,18 @@
     <table class="table-fixed w-full text-center text-[12px] md:text-base print:text-sm print:leading-none print:py-[15px]">
       <thead>
         <tr class="text-[10px] md:text-base print:text-[9px]">
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-4 md:w-8 print:w-8">日</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-4 md:w-8 print:w-8">曜日</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">就床時刻</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">就寝時刻</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">覚醒時刻</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-10 md:w-16 print:w-14">起床時刻</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-12 md:w-24 print:w-20">睡眠時間</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-16 print:w-8">中途覚醒(回)</th>
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-16 print:w-8">昼寝時間(分)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[5%] md:w-8 print:w-8">日</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[5%] md:w-8 print:w-8">曜日</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">就床時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">就寝時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">覚醒時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[12%] md:w-16 print:w-14">起床時刻</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[15%] md:w-24 print:w-20">睡眠時間</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base">中途覚醒(回)</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[8%] md:w-16 print:w-8 text-[8px] md:text-base">昼寝時間(分)</th>
           <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-1/3 max-w-[33%] print:w-56 print:max-w-1/3 hidden md:table-cell">備考</th>
           <!-- 編集ボタンのみプリントしない -->
-          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-8 md:w-8 print:hidden">編集</th>
+          <th class="border border-secondary bg-primary sticky top-0 z-10 md:static w-[9%] md:w-8 print:hidden">編集</th>
         </tr>
       </thead>
 

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -35,7 +35,10 @@
 
     <!-- 印刷時非表示: 印刷ボタン -->
     <div class="print:hidden">
-      <button onclick="print(); return false;" id="printButton" class="btn bg-primary btn-xs sm:btn-sm md:btn-md rounded text-sm md:text-base text-neutral">
+      <button onclick="print(); return false;" id="printButton" class="btn bg-primary btn-xs sm:btn-sm md:btn-md text-sm md:text-base text-neutral">
+        <span class="material-symbols-outlined text-sm md:text-xl">
+          print
+        </span>
         印刷する
       </button>
     </div>

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -4,14 +4,19 @@
     <!-- 印刷時非表示: 年月選択 -->
     <div class="print:hidden">
       <%= form_with(url: sleep_logs_path, method: :get, data: { turbo: true }) do |f| %>
-        <div class="form-group btn bg-primary px-4 py-2 rounded relative overflow-hidden cursor-pointer"
+        <div class="btn flex items-center form-group btn-xs sm:btn-sm md:btn-md bg-primary relative overflow-hidden cursor-pointer text-xs md:text:base text-neutral"
             onclick="document.getElementById('year_month_selector').showPicker();">
+          <span class="material-symbols-outlined text-sm md:text-xl">
+            calendar_month
+          </span>
+          <!-- 年月直接入力をナシに -->
           <span class="pointer-events-none">
             <%= @selected_date.strftime('%Y年%m月') %>
           </span>
+          <!-- 13機関みたいな存在感 -->
           <%= f.month_field :year_month,
                             id: 'year_month_selector',
-                            class: 'absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer',
+                            class: 'absolute top-0 left-0 w-full h-full opacity-0',
                             value: @selected_date.strftime('%Y-%m'),
                             onchange: 'this.form.submit();' %>
         </div>
@@ -30,7 +35,7 @@
 
     <!-- 印刷時非表示: 印刷ボタン -->
     <div class="print:hidden">
-      <button onclick="print(); return false;" id="printButton" class="btn bg-primary rounded text-sm md:text-base">
+      <button onclick="print(); return false;" id="printButton" class="btn bg-primary btn-xs sm:btn-sm md:btn-md rounded text-sm md:text-base text-neutral">
         印刷する
       </button>
     </div>

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -1,12 +1,17 @@
-<div class="my-32 print:my-0">
-  <div class="mb-12 flex justify-center items-center print:m-2">
+<div class="print:my-0 print:space-y-0 my-6 md:my-16 w-full space-y-4 md:space-y-16">
+  <div class="flex justify-center items-center print:m-2">
 
     <!-- 印刷時非表示: 年月選択 -->
     <div class="print:hidden">
       <%= form_with(url: sleep_logs_path, method: :get, data: { turbo: true }) do |f| %>
-        <div class="form-group btn bg-primary text-neutral px-4 py-2 rounded">
+        <div class="form-group btn bg-primary px-4 py-2 rounded relative overflow-hidden cursor-pointer"
+            onclick="document.getElementById('year_month_selector').showPicker();">
+          <span class="pointer-events-none">
+            <%= @selected_date.strftime('%Y年%m月') %>
+          </span>
           <%= f.month_field :year_month,
-                            class: 'form-control bg-primary',
+                            id: 'year_month_selector',
+                            class: 'absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer',
                             value: @selected_date.strftime('%Y-%m'),
                             onchange: 'this.form.submit();' %>
         </div>
@@ -19,13 +24,13 @@
     </div>
 
     <!-- タイトル -->
-    <div class="mx-8 text-center font-bold text-lg">
+    <div class="mx-8 text-center font-bold text-base md:text-xl">
       睡眠日誌
     </div>
 
     <!-- 印刷時非表示: 印刷ボタン -->
     <div class="print:hidden">
-      <button onclick="print(); return false;" id="printButton" class="btn bg-primary text-neutral px-4 py-2 rounded">
+      <button onclick="print(); return false;" id="printButton" class="btn bg-primary rounded text-sm md:text-base">
         印刷する
       </button>
     </div>
@@ -53,7 +58,7 @@
   </div>
 
   <!-- 睡眠記録テーブル -->
-  <div class="mx-32 flex justify-center">
+  <div class="mx-2 md:mx-32 flex justify-center">
         <%= render 'logs_table' %>
   </div>
 </div>

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -51,7 +51,7 @@
     <!-- Turbo Frameでモーダルの設定 -->
     <!-- daisyUIのモーダルを採用, submit後にもモーダルを閉じさせるし、どんな閉じ方しても閉じたよ〜ってのを他のactionにも伝える -->
     <dialog id="my_modal_3" class="modal" data-controller="modal" data-modal-target="dialog" data-action="turbo:submit-end->modal#formSubmission modal:close->modal#clearModal">
-      <div class="modal-box h-auto">
+      <div class="modal-box h-auto bg-secondary">
         <!-- エラーメッセージ表示用Turbo Frame -->
         <%= turbo_frame_tag "modal_error_message_frame" %>
 

--- a/app/views/sleep_logs/index.html.erb
+++ b/app/views/sleep_logs/index.html.erb
@@ -1,10 +1,10 @@
-<div class="print:my-0 print:space-y-0 my-6 md:my-16 w-full space-y-4 md:space-y-16">
+<div class="print:my-0 print:space-y-0 my-8 md:my-16 w-full space-y-6 md:space-y-16">
   <div class="flex justify-center items-center print:m-2">
 
     <!-- 印刷時非表示: 年月選択 -->
     <div class="print:hidden">
       <%= form_with(url: sleep_logs_path, method: :get, data: { turbo: true }) do |f| %>
-        <div class="btn flex items-center form-group btn-xs sm:btn-sm md:btn-md bg-primary relative overflow-hidden cursor-pointer text-xs md:text:base text-neutral"
+        <div class="btn flex items-center form-group btn-xs sm:btn-sm md:btn-md bg-primary relative overflow-hidden cursor-pointer text-xs md:text-base text-neutral"
             onclick="document.getElementById('year_month_selector').showPicker();">
           <span class="material-symbols-outlined text-sm md:text-xl">
             calendar_month
@@ -66,7 +66,7 @@
   </div>
 
   <!-- 睡眠記録テーブル -->
-  <div class="mx-2 md:mx-32 flex justify-center">
+  <div class="mx-0 ms:mx-2 md:mx-32 flex justify-center">
         <%= render 'logs_table' %>
   </div>
 </div>

--- a/app/views/users/registrations/edit_password.html.erb
+++ b/app/views/users/registrations/edit_password.html.erb
@@ -1,40 +1,48 @@
-<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ユーザー設定</h2>
-  </div>
+<div class="relative flex flex-col justify-center items-center py-6 md:py-16 flex min-h-full">
+  <div class="card bg-secondary w-96 shadow-sm p-8">
+    <div>
+      <h2 class="mt-10 text-center text-2xl/9 font-bold">パスワード変更</h2>
+    </div>
 
-  <%= form_with model: current_user, url: users_update_password_path, method: :patch, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
-    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <%= render "users/shared/error_messages", resource: current_user %> <!-- エラー発生時の部分テンプレート -->
+    <%= form_with model: current_user, url: users_update_password_path, method: :patch, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
+      <div class="mt-10 space-y-4 w-full">
+        <%= render "users/shared/error_messages", resource: current_user %> <!-- エラー発生時の部分テンプレート -->
 
-      <!-- パスワード -->
-      <div>
-        <%= f.label :current_password, "今のパスワード", class: "block text-sm/6 font-medium text-neutral"%>
+        <!-- パスワード -->
+        <div>
+          <%= f.label :current_password, "今のパスワード", class: "block text-sm/6 font-medium"%>
+          <div class="mt-2">
+            <%= f.password_field :current_password, autocomplete: "current-password" , class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <%= f.label :password, "新しいパスワード", class: "block text-sm/6 font-medium"%>
+        </div>
+        <% if @minimum_password_length %>
+          <em class="text-sm text-gray-500">(<%= @minimum_password_length %>文字以上でしくよろ)</em>
+        <% end %>
         <div class="mt-2">
-          <%= f.password_field :current_password, autocomplete: "current-password" , class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード確認", class: "block text-sm/6 font-medium"%>
+          <div class="mt-2">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" , class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
+          </div>
         </div>
       </div>
 
-      <div class="flex items-center justify-between">
-        <%= f.label :password, "新しいパスワード", class: "block text-sm/6 font-medium text-neutral"%>
-      </div>
-      <% if @minimum_password_length %>
-        <em class="text-sm text-gray-500">(<%= @minimum_password_length %>文字以上でしくよろ)</em>
-      <% end %>
-      <div class="mt-2">
-        <%= f.password_field :password, autocomplete: "new-password", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral  outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-      </div>
-
-      <div>
-        <%= f.label :password_confirmation, "新しいパスワード確認", class: "block text-sm/6 font-medium text-neutral"%>
-        <div class="mt-2">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password" , class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-        </div>
-      </div>
-
-      <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+      <div class="actions mt-10 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 font-semibold text-primary shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
         <%= f.submit "パスワードを変更する"%>
       </div>
+    <% end %>
+
+    <div class="mt-8 text-center">
+      <div>
+        <%= link_to "ユーザー設定に戻る", users_edit_profile_path %>
+      </div>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/users/registrations/edit_profile.html.erb
+++ b/app/views/users/registrations/edit_profile.html.erb
@@ -1,41 +1,43 @@
-<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold">ユーザー設定</h2>
-  </div>
-
-  <%= form_with model: current_user, url: users_update_profile_path, method: :patch, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
-    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <%= render "users/shared/error_messages", resource: current_user %> <!-- エラー発生時の部分テンプレート -->
-
-      <!-- お名前 -->
-      <div>
-        <%= f.label :name, "お名前", class:  "block text-sm/6 font-medium"%>
-        <div class="mt-2">
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-        </div>
-      </div>
-
-      <!-- メールアドレス -->
-      <div>
-        <%= f.label :email, "メールアドレス", class: "block text-sm/6 font-medium"%>
-        <div class="mt-2">
-          <%= f.email_field :email, autocomplete: "email", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-        </div>
-      </div>
-
-      <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-        <%= f.submit "更新"%>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+<div class="relative flex-col justify-center items-center py-6 md:py-16 flex min-h-full">
+  <div class="card bg-secondary w-96 shadow-sm p-8">
     <div>
-      <%= link_to "パスワード変更", :users_edit_password %>
+      <h2 class="mt-10 text-center text-2xl/9 font-bold">ユーザー設定</h2>
     </div>
 
-    <div class="mt-4 text-warning">
-      <%= link_to "退会はこちら", :users_unsubscribe_confirm %>
+    <%= form_with model: current_user, url: users_update_profile_path, method: :patch, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
+      <div class="mt-10 space-y-4 w-full">
+        <%= render "users/shared/error_messages", resource: current_user %> <!-- エラー発生時の部分テンプレート -->
+
+        <!-- お名前 -->
+        <div>
+          <%= f.label :name, "お名前", class:  "block text-sm/6 font-medium"%>
+          <div class="mt-2">
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
+          </div>
+        </div>
+
+        <!-- メールアドレス -->
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm/6 font-medium"%>
+          <div class="mt-2">
+            <%= f.email_field :email, autocomplete: "email", class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
+          </div>
+        </div>
+      </div>
+
+        <div class="actions mt-10 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 font-semibold text-primary shadow-sm">
+          <%= f.submit "更新"%>
+        </div>
+    <% end %>
+
+    <div class="mt-10 text-center">
+      <div>
+        <%= link_to "パスワード変更", :users_edit_password %>
+      </div>
+
+      <div class="mt-4 text-warning">
+        <%= link_to "退会はこちら", :users_unsubscribe_confirm %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,45 +1,45 @@
-<div class="flex justify-center py-16 w-full">
+<div class="flex justify-center py-6 md:py-16 w-full">
   <div class="w-96">
     <%= form_with model: @user, url: user_registration_path, data: { turbo: false } do |f| %>
-      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-6">
+      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-4 md:p-6">
         <legend class="fieldset-legend text-2xl font-semibold">新規登録</legend>
 
         <%= render "users/shared/error_messages", resource: resource %>
 
-        <div class="form-control space-y-4">
+        <div class="form-control space-y-1 md:space-y-4">
           <div>
-            <%= f.label :name, "お名前", class: "label" %>
+            <%= f.label :name, "お名前", class: "label text-sm md:text-base" %>
             <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "お名前を入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <div>
-            <%= f.label :email, "メールアドレス", class: "label" %>
+            <%= f.label :email, "メールアドレス", class: "label text-sm md:text-base" %>
             <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレスを入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <div>
             <div class="flex items-center justify-between">
-              <%= f.label :password, "パスワード", class: "label" %>
+              <%= f.label :password, "パスワード", class: "label text-sm md:text-base" %>
               <% if @minimum_password_length %>
-                <span class="label-text-alt text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
+                <span class="label-text-alt text-xs md:text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
               <% end %>
             </div>
             <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワードを入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <div>
-            <%= f.label :password_confirmation, "パスワード確認", class: "label" %>
+            <%= f.label :password_confirmation, "パスワード確認", class: "label text-sm md:text-base" %>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを再入力", class: "input input-bordered w-full bg-primary" %>
           </div>
         </div>
 
-        <div class="actions mt-8">
-          <%= f.submit "登録", class: "btn btn-accent w-full" %>
+        <div class="actions mt-6 md:mt-8">
+          <%= f.submit "登録", class: "btn btn-accent w-full text-sm md:text-base" %>
         </div>
       </fieldset>
     <% end %>
 
-    <div class="mt-6 text-center">
+    <div class="mt-4 md:mt-6 text-center">
       <%= render "users/shared/links" %>
     </div>
   </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,53 +1,45 @@
-<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">新規登録</h2>
-  </div>
+<div class="flex justify-center py-16 w-full">
+  <div class="w-96">
+    <%= form_with model: @user, url: user_registration_path, data: { turbo: false } do |f| %>
+      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-6">
+        <legend class="fieldset-legend text-2xl font-semibold">新規登録</legend>
 
-  <%= form_with model: @user, url: user_registration_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
-    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <%= render "users/shared/error_messages", resource: resource %> <!-- エラー発生時の部分テンプレート -->
+        <%= render "users/shared/error_messages", resource: resource %>
 
-      <!-- お名前 -->
-      <div>
-        <%= f.label :name, "お名前", class:  "block text-sm/6 font-medium text-neutral"%>
-        <div class="mt-2">
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        <div class="form-control space-y-4">
+          <div>
+            <%= f.label :name, "お名前", class: "label" %>
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "お名前を入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
+
+          <div>
+            <%= f.label :email, "メールアドレス", class: "label" %>
+            <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレスを入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
+
+          <div>
+            <div class="flex items-center justify-between">
+              <%= f.label :password, "パスワード", class: "label" %>
+              <% if @minimum_password_length %>
+                <span class="label-text-alt text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
+              <% end %>
+            </div>
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワードを入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
+
+          <div>
+            <%= f.label :password_confirmation, "パスワード確認", class: "label" %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを再入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
         </div>
-      </div>
 
-      <!-- メールアドレス -->
-      <div>
-        <%= f.label :email, "メールアドレス", class: "block text-sm/6 font-medium text-neutral"%>
-        <div class="mt-2">
-          <%= f.email_field :email, autocomplete: "email", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
+        <div class="actions mt-8">
+          <%= f.submit "登録", class: "btn btn-accent w-full" %>
         </div>
-      </div>
+      </fieldset>
+    <% end %>
 
-      <!-- パスワード -->
-      <div class="flex items-center justify-between">
-        <%= f.label :password, "パスワード", class: "block text-sm/6 font-medium text-neutral"%>
-      </div>
-      <% if @minimum_password_length %>
-        <em class="text-sm text-gray-500">(<%= @minimum_password_length %>文字以上でしくよろ)</em>
-      <% end %>
-      <div class="mt-2">
-        <%= f.password_field :password, autocomplete: "new-password", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral  outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-      </div>
-
-      <div>
-        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm/6 font-medium text-neutral"%>
-        <div class="mt-2">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password" , class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-        </div>
-      </div>
-
-      <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-        <%= f.submit "登録"%>
-      </div>
-    </div>
-  <% end %>
-
-    <div class="mt-6 flex justify-center block text-sm/6 font-medium text-neutral underline underline-offset-1">
+    <div class="mt-6 text-center">
       <%= render "users/shared/links" %>
     </div>
   </div>

--- a/app/views/users/registrations/unsubscribe_confirm.html.erb
+++ b/app/views/users/registrations/unsubscribe_confirm.html.erb
@@ -1,21 +1,21 @@
-<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ユーザー退会</h2>
-  </div>
+<div class="relative flex flex-col items-center py-6 md:py-16 min-h-screen bg-error">
+  <div class="card mt-10 bg-secondary w-96 shadow-sm p-8">
+    <h2 class="text-center text-2xl/9 font-bold">ユーザー退会</h2>
 
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <div class="mt-10 text-center text-neutral">
-      <p>退会すると、これまでの保存データが全て消えてしまします。</p>
-      <p>2度と戻りません。</p>
-      <p class="text-warning">本当に退会しますか？</p>
+    <div class="w-full">
+      <div class="mt-8 text-center text-neutral">
+        <p>退会すると、これまでの保存データが<br />全て消えてしまいます。</p>
+        <p>2度と戻りません。</p>
+        <p class="text-warning">本当に退会しますか？</p>
+      </div>
     </div>
-  </div>
 
-  <div class="actions mt-8 flex w-full justify-center rounded-md bg-warning px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-    <%= button_to "退会する", users_destroy_path, method: :delete %>
-  </div>
+    <div class="actions mt-8 flex w-full justify-center rounded-md bg-warning px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+      <%= button_to "退会する", users_destroy_path, method: :delete, data: { turbo: false } %>
+    </div>
 
-  <div class="mt-8 text-center">
-    <%= link_to "やっぱりやめる", users_edit_profile_path %>
+    <div class="mt-8 text-center underline underline-offset-2">
+      <%= link_to "やっぱりやめる", users_edit_profile_path %>
+    </div>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="relative top-24 flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+<div class="">
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ログイン</h2>
   </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,45 +1,46 @@
-<div class="">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold text-neutral">ログイン</h2>
-  </div>
+<div class="flex justify-center py-16 w-full">
+  <div class="w-96">
+    <%= form_with model: @user, url: user_session_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
+      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-6">
+        <legend class="fieldset-legend text-2xl font-semibold">ログイン</legend>
 
-<%= form_with model: @user, url: user_session_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+        <%= render "users/shared/error_messages", resource: resource %>
 
-  <!-- メールアドレス -->
-  <div>
-    <%= f.label :email, "メールアドレス", class: "block text-sm/6 font-medium text-neutral"%>
-    <div class="mt-2">
-      <%= f.email_field :email, autocomplete: "email", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-    </div>
-  </div>
+        <div class="form-control space-y-6">
+          <!-- メールアドレス -->
+          <div>
+            <%= f.label :email, "メールアドレス", class: "label" %>
+            <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレスを入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
 
+          <!-- パスワード -->
+          <div>
+            <div class="flex items-center justify-between">
+              <%= f.label :password, "パスワード", class: "label" %>
+              <% if @minimum_password_length %>
+                <span class="label-text-alt text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
+              <% end %>
+            </div>
+            <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力", class: "input input-bordered w-full bg-primary" %>
+          </div>
 
-  <!-- パスワード -->
-  <div class="flex items-center justify-between">
-    <%= f.label :password, "パスワード", class: "block text-sm/6 font-medium text-neutral"%>
-  </div>
-  <div class="mt-2">
-    <%= f.password_field :password, autocomplete: "current-password", class: "block w-full rounded-md bg-primary px-3 py-1.5 text-base text-neutral  outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm" %>
-  </div>
+          <div class="flex items-center">
+            <% if devise_mapping.rememberable? %>
+              <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+              <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-neutral" %>
+            <% end %>
+          </div>
 
-  <div class="mt-4 flex items-center">
-    <% if devise_mapping.rememberable? %>
-      <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
-      <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-neutral" %>
+        <div class="actions">
+          <%= f.submit "ログイン", class: "btn btn-accent w-full" %>
+        </div>
+      </fieldset>
     <% end %>
-  </div>
 
-  <div class="actions mt-8 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-    <%= f.submit "ログイン" %>
-  </div>
-<% end %>
+    <div class="mt-6 text-center">
+      <%= render "users/shared/links" %>
+    </div>
 
-  <div class="mt-6 flex justify-center block text-sm/6 font-medium text-neutral underline underline-offset-1">
-    <%= render "users/shared/links" %>
-  </div>
 
-  <div class="mt-6 flex justify-center block text-sm/6 font-medium text-neutral underline underline-offset-1">
-  <%= link_to "パスワードを忘れた場合", new_user_password_path %>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,12 +1,12 @@
-<div class="flex justify-center py-16 w-full">
+<div class="flex justify-center py-6 md:py-16 w-full">
   <div class="w-96">
     <%= form_with model: @user, url: user_session_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
-      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-6">
+      <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-4 md:p-6">
         <legend class="fieldset-legend text-2xl font-semibold">ログイン</legend>
 
         <%= render "users/shared/error_messages", resource: resource %>
 
-        <div class="form-control space-y-6">
+        <div class="form-control space-y-4">
           <!-- メールアドレス -->
           <div>
             <%= f.label :email, "メールアドレス", class: "label" %>
@@ -37,7 +37,7 @@
       </fieldset>
     <% end %>
 
-    <div class="mt-6 text-center">
+    <div class="mt-4 md:mt-6 text-center">
       <%= render "users/shared/links" %>
     </div>
 

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-cache="false" class="text-warning">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "ログイン", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name), class: "underline underline-offset-2" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -8,7 +8,20 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false } %><br />
+    <% if provider == :google_oauth2 %>
+      <!-- 新規登録かログインかで文字を変える -->
+      <%
+        button_text = if devise_mapping.registerable? && controller_name != 'users/registrations'
+                        "Sign up with Google"
+                      else
+                        "Sign in with Google"
+                      end
+      %>
+      <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false }, class: "btn mt-4 rounded-xl bg-primary border-base-300" do %>
+        <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
+        <%= button_text %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,36 +1,46 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "ログイン", new_session_path(resource_name), class: "underline underline-offset-2" %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規登録", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <% if provider == :google_oauth2 %>
-      <!-- 新規登録かログインかで文字を変える -->
-      <%
-        button_text = if devise_mapping.registerable? && controller_name != 'users/registrations'
-                        "Sign up with Google"
-                      else
-                        "Sign in with Google"
-                      end
-      %>
-      <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false }, class: "btn mt-4 rounded-xl bg-primary border-base-300" do %>
-        <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
-        <%= button_text %>
+<div class="space-y-4">
+  <div>
+    <%- if devise_mapping.omniauthable? %>
+      <%- resource_class.omniauth_providers.each do |provider| %>
+        <% if provider == :google_oauth2 %>
+          <!-- 新規登録かログインかで文字を変える -->
+          <%
+            button_text = if devise_mapping.registerable? && controller_name != 'users/registrations'
+                            "Sign up with Google"
+                          else
+                            "Sign in with Google"
+                          end
+          %>
+          <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false }, class: "btn mt-4 rounded-xl bg-primary border-base-300" do %>
+            <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
+            <%= button_text %>
+          <% end %>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-<% end %>
+  </div>
 
+  <div>
+    <%- if controller_name != 'sessions' %>
+      <%= link_to "ログイン", new_session_path(resource_name), class: "underline underline-offset-2" %>
+    <% end %>
+  </div>
+
+  <div>
+    <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+      <%= link_to "新規登録", new_registration_path(resource_name), class: "underline underline-offset-2" %>
+    <% end %>
+  </div>
+
+  <div>
+    <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+      <%= link_to "パスワードを忘れちゃった?", new_password_path(resource_name), class: "underline underline-offset-2 text-error" %>
+    <% end %>
+  </div>
+</div>
 
 <%
 =begin%>
- <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードを忘れちゃった?", new_password_path(resource_name) %><br />
-<% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "お前はお前の道を征く?", new_confirmation_path(resource_name) %><br />

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,7 @@ start_date = today.beginning_of_month
 end_date = today.end_of_month
 
 (start_date..end_date).each do |current_date|
+  sleep_date = current_date
   before_date = current_date - 1.day
   go_to_bed_at = before_date.to_datetime.change(hour: 22, min: 0)
   fell_asleep_at = before_date.to_datetime.change(hour: 23, min: 0)
@@ -14,7 +15,7 @@ end_date = today.end_of_month
 
   sleep_log = SleepLog.create!(
     user: user,
-    sleep_date: date,
+    sleep_date: sleep_date,
     go_to_bed_at: go_to_bed_at,
     fell_asleep_at: fell_asleep_at,
     woke_up_at: woke_up_at,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,12 @@ today = Date.today
 start_date = today.beginning_of_month
 end_date = today.end_of_month
 
-(start_date..end_date).each do |date|
-  go_to_bed_at = date.to_datetime.change({ hour: 22, min: 0 })
-  fell_asleep_at = date.to_datetime.change({ hour: 23, min: 0 })
-  woke_up_at = (date + 1).to_datetime.change({ hour: 6, min: 30 })
-  leave_bed_at = (date + 1).to_datetime.change({ hour: 7, min: 0 })
+(start_date..end_date).each do |current_date|
+  before_date = current_date - 1.day
+  go_to_bed_at = before_date.to_datetime.change(hour: 22, min: 0)
+  fell_asleep_at = before_date.to_datetime.change(hour: 23, min: 0)
+  woke_up_at = current_date.to_datetime.change(hour: 6, min: 30)
+  leave_bed_at = current_date.to_datetime.change(hour: 7, min: 0)
 
   sleep_log = SleepLog.create!(
     user: user,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,12 +9,12 @@ module.exports = {
     extend: {
       keyframes: {
         flashMessageIn: { // スライドイン・フェードイン
-          '0%': { opacity: 0, transform: 'translateY(0)'},
-          '20%': { opacity: 1, transform: 'translateY(100%)' },
+          '0%': { opacity: 0, transform: 'translateX(-100%)'},
+          '20%': { opacity: 1, transform: 'translateX(0)' },
           },
           flashMessageOut: { // スライドアウト・フェードアウト
-            '80%': { opacity: 1, transform: 'translateY(100%)' },
-            '100%': { opacity: 0, transform: 'translateY(0)' },
+            '80%': { opacity: 1, transform: 'translateX(0)' },
+            '100%': { opacity: 0, transform: 'translateX(-100%)' },
           },
         },
         animation: {


### PR DESCRIPTION
close #91 
17時間

# 概要
各ページの見た目を整える

# 主な変更
- 使い方（ルートファイル）
- 睡眠記録画面
- 新規登録画面
- ログイン画面
- パスワードを忘れた場合
- パスワード再設定
- ユーザー設定
- パスワード変更
- ユーザー退会
- ヘッダー(ログイン前・後)
- フッター

- 入力スタイルをやっぱりDateTime型からTime型に戻した

# Lintチェック
[![Image from Gyazo](https://i.gyazo.com/79b5534c6af1faa9e6a2a1817b9839f4.png)](https://gyazo.com/79b5534c6af1faa9e6a2a1817b9839f4)