### PR TITLE
[FIX]#33 使い方ページで画面がスマホサイズの時に画像と文章が横並びになったままだったのを修正

### DIFF
--- a/app/views/headers/how_to_use.html.erb
+++ b/app/views/headers/how_to_use.html.erb
@@ -36,7 +36,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">年月選択</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/02_choice_month.jpg", class: "rounded-xl w-fit h-auto object-cover") %>
             </div>
@@ -49,7 +49,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">睡眠を記録する</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/03_record_a_sleep_log.jpg", class: "rounded-xl w-full h-auto object-cover") %>
             </div>
@@ -67,7 +67,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">記録後、即座に反映されます</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/04_recorded.jpg", class: "rounded-xl w-fit h-auto object-cover") %>
             </div>
@@ -81,7 +81,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">記録を印刷する</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/05_print_button.jpg", class: "rounded-xl w-fit h-auto object-cover") %>
             </div>
@@ -94,7 +94,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">印刷ボタンを押すと、印刷ダイアログが表示されます。</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/06_print_dialog.jpg", class: "rounded-xl w-fit h-auto object-cover") %>
             </div>
@@ -107,7 +107,7 @@
       <div class="collapse collapse-plus bg-base-100 border border-base-300">
         <input type="radio" name="my-accordion-3" checked="checked" />
         <div class="collapse-title font-semibold">このまま睡眠日誌として提出できるぜ！</div>
-          <div class="collapse-content flex flex-row justify-center items-center gap-6">
+          <div class="collapse-content flex flex-col-reverse md:flex-row justify-center items-center gap-6">
             <div class="w-full md:w-1/2">
               <%= image_tag("how_to_use/07_printed", class: "rounded-xl w-fit h-auto object-cover") %>
             </div>


### PR DESCRIPTION
5分くらい

# 概要
使い方ページで画面がスマホサイズの時に画像と文章が横並びになったままだったのを修正

# 主な変更
- `app/views/headers/how_to_use.html.erb`で`flex-col-reverse`を入れ忘れていた部分を修正