### PR TITLE
[ADD]#38 Stimulusコンポーネントで文字数カウンターを追加

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import CharacterCounter from 'stimulus-character-counter'
 
 const application = Application.start()
+application.register('character-counter', CharacterCounter)
 
 // Configure Stimulus development experience
 application.debug = process.env.NODE_ENV === 'development'

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -71,15 +71,20 @@
         <% end %>
       </div>
 
-      <div>
+      <div data-controller="character-counter">
         <%= f.label :comment, "備考(42文字まで)", class: "block text-sm font-medium mb-1" %>
-        <%= f.text_area :comment, max: 42,
-                          class: "textarea textarea-bordered w-full bg-primary indent-1 text-sm resize-y",
-                          placeholder:"昨夜はよく眠れましたか？　薬は飲みましたか？",
-                          data: { controller: "textarea-autoresize", action: "input->textarea-autoresize#resize" } %>
-        <% if f.object.errors[:comment].any? %>
-          <p class="text-error text-xs mt-1"><%= f.object.errors[:comment].join(", ") %></p>
-        <% end %>
+
+        <%= f.text_area :comment, maxlength: 42,
+          class: "textarea textarea-bordered w-full bg-primary indent-1 text-sm resize-y",
+          placeholder: "昨夜はよく眠れましたか？　薬は飲みましたか？",
+          data: {
+            "character-counter-target": "input"
+          } %>
+        <p class="text-end text-sm">
+          <strong data-character-counter-target="counter"></strong>/42文字
+        </p>
+
+
       </div>
 
       <div>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.14",
     "postcss": "^8.4.49",
+    "stimulus-character-counter": "^4.2.0",
     "tailwindcss": "^3.4.15",
     "tailwindcss-stimulus-components": "^6.1.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,6 +833,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-character-counter@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stimulus-character-counter/-/stimulus-character-counter-4.2.0.tgz#6e7782c2c525ccc661ffbb39a7b15085a3a42a21"
+  integrity sha512-5ZN5wFlOnIkZRSiwtC7zb880yvE4O/4+KOhdg0z6zQet4iLA2+W0NJvHX5teW6tl5M1IGzHrgOtuEsUVfQ2TrA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
40分くらい

# 概要
Stimulusコンポーネントで文字数カウンターを追加

# 主な変更
- [Character Counter](https://www.stimulus-components.com/docs/stimulus-character-counter)のコンポーネントを利用
- `app/views/sleep_logs/_form.html.erb`の備考欄に導入