### PR TITLE
[render preview][FIX] DockerでUTCとして扱われていた問題を一旦削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN rm -rf /var/lib/apt/lists /var/cache/apt/archives
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development" \
+    TZ=Asia/Tokyo
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,10 @@ RUN rm -rf /var/lib/apt/lists /var/cache/apt/archives
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development" \
-    TZ=UTC
+    BUNDLE_WITHOUT="development"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build
-
-# 祈りのUTCタイムゾーン
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install packages needed to build gems and node modules ファイナルステージ！
 RUN apt-get update -qq && \

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,5 @@
 <div class="flex justify-center py-6 md:py-16 w-full">
   <div class="w-96">
-    <h1>プルリク画面だよーん</h1>
     <%= form_with model: @user, url: user_session_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
       <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-4 md:p-6">
         <legend class="fieldset-legend text-2xl font-semibold">ログイン</legend>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,6 @@
 <div class="flex justify-center py-6 md:py-16 w-full">
   <div class="w-96">
+    <h1>プルリク画面だよーん</h1>
     <%= form_with model: @user, url: user_session_path, data: { turbo: false } do |f| %> <!-- Userモデルに送る -->
       <fieldset class="fieldset bg-secondary border-base-300 rounded-box border p-4 md:p-6">
         <legend class="fieldset-legend text-2xl font-semibold">ログイン</legend>


### PR DESCRIPTION
# 概要
Renderのプレビュー機能を使って、本番環境でもUTCで日付表示されてしまわないか確認

# 主な変更
原因としては、OS環境のタイムゾーンがUTCになっていたためだと思われる
保存のみUTCで管理して、そのほか表示などはAsia/Tokyoで扱いたかったのだが、この辺りを混同していた
- DockerfileのTZを、Dockerfile.devと同じく`ENV TZ Asia/Tokyo`と追記
- Render側のEnvironment VariablesにKEY: TZ, Value: Asia/Tokyoを指定(RenderのデフォルトOSはタイムゾーンがUTCのため)