### PR TITLE
[FIX]#43 ヘッダーの記録するボタンを押したらrootパスではなく記録画面に遷移するよう修正

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="space-x-1 md:space-x-4 text-xs ms:text-sm md:text-base">
       <%= link_to "使いかた", headers_how_to_use_path, class: "hover:text-primary" %>
-      <%= link_to "記録する", root_path, class: "hover:text-primary" %>
+      <%= link_to "記録する", sleep_logs_path, class: "hover:text-primary" %>
       <%= link_to "新規登録", new_user_registration_path, class: "hover:text-primary" %>
       <%= link_to "ログイン", new_user_session_path, method: :delete, class: "hover:text-primary" %>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="space-x-1 md:space-x-4 text-xs ms:text-sm md:text-base">
       <%= link_to "使いかた", headers_how_to_use_path, class: "hover:text-primary" %>
-      <%= link_to "記録する", root_path, class: "hover:text-primary" %>
+      <%= link_to "記録する", sleep_logs_path, class: "hover:text-primary" %>
       <%= link_to "設定", users_edit_profile_path, class: "hover:text-primary" %>
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "hover:text-primary" %>
     </div>


### PR DESCRIPTION
# 概要
ヘッダーの記録するボタンを押したらrootパスではなく記録画面に遷移するよう修正

# 主な変更
ログイン前後の各ヘッダーのリンク先を変更