### PR TITLE
[FIX]#44 リンク末尾に/がついていたので削除

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,14 +7,14 @@ module ApplicationHelper
       charset: "utf-8",
       description: "元睡眠病患者が作った、印刷機能付きの睡眠日誌作成ツールです。",
       keywords: "睡眠,睡眠病,睡眠クリニック,睡眠日誌,睡眠記録,突発性過眠症",
-      canonical: "https://sleeplogger.onrender.com/",
+      canonical: "https://sleeplogger.onrender.com",
       separator: "|",
       og: {
         site_name: :site,
         title: :title,
         description: :description,
         type: "website",
-        url: "https://sleeplogger.onrender.com/",
+        url: "https://sleeplogger.onrender.com",
         image: image_url("ogp.png"),
         local: "ja-JP"
       },


### PR DESCRIPTION
# 概要
静的OGPが表示されない問題を解決

# 主な変更
- `app/helpers/application_helper.rb`で"https://sleeplogger.onrender.com/",というように末尾に/がついていたのを削除