### PR TITLE
[FIX]#45 過分クエリを減らす

### DIFF
--- a/app/controllers/sleep_logs_controller.rb
+++ b/app/controllers/sleep_logs_controller.rb
@@ -141,13 +141,17 @@ class SleepLogsController < ApplicationController
     end
     @start_date = @selected_date.beginning_of_month # 1日or本日の日付の月初を設定
     @end_date = @selected_date.end_of_month # 1日or本日の月末を設定
-    sleep_logs = current_user.sleep_logs.where(sleep_date: @start_date..@end_date).includes(:awakening, :napping_time, :comment) # 子クラスを含むsleep_logモデルを月初〜月末分取得する
+    sleep_logs = current_user.sleep_logs # 現ユーザーの睡眠記録の中から
+                             .where(sleep_date: @start_date..@end_date) # その月の月初から月末までの日付のみ
+                             .includes(:awakening, :napping_time, :comment) # 子クラスを含むsleep_logモデルを月初〜月末分取得する
+                             .index_by(&:sleep_date) # sleep_dateをキー・日付をバリューとしてハッシュ変換
 
     all_dates = (@start_date..@end_date).to_a # 月初から月末までの範囲オブジェクトを配列にする
 
     # データが存在しない日は日付で埋める
     @sleep_logs = all_dates.map do |sleep_date|
-      sleep_logs.find { |sleep_log| sleep_log.sleep_date == sleep_date } || current_user.sleep_logs.build(sleep_date: sleep_date)
+      # sleep_dateキーから値を探す
+      sleep_logs[sleep_date] || current_user.sleep_logs.build(sleep_date: sleep_date)
     end
   end
 end

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -2,7 +2,7 @@ class SleepLogForm
   # ActiveModelを使ってフォームバリデーション
   include ActiveModel::Model # 通常のモデルと同じくバリデーションを使えるように
   include ActiveModel::Attributes # attr_accessorと同じように属性が使える
-  # include ActiveModel::Validations::Callbacks # before_validation用
+  #include ActiveModel::Validations::Callbacks # before_validation用
 
   # パラメータの読み書きを許可する。指定の属性に変換してくれる。デフォルト値も設定可能。各モデルで扱いたいカラム名をインスタンス変数名としている。
   attribute :user_id, :integer
@@ -33,7 +33,7 @@ class SleepLogForm
   validates :comment, length: { maximum: 42 }
 
   # バリデーション前に時刻の論理的な日付調整を行う
-  # after_validation :validate_sleep_times_order
+  # after_validation :validated_flash
 
   # 純粋なバリデーション祭の直後にカスタムバリデート祭開催
   validate :validate_sleep_times_order # 日時の論理性
@@ -70,6 +70,7 @@ class SleepLogForm
     # sleep_log の値を使って self に代入（formオブジェクトの属性を更新）
 
     # バリデーションに引っかかる場合は以降の処理にせずfalseをコントローラーに返す
+    pp "バリデーションはつどう"
     return false unless valid? # 上記のvalidatesをチェック
 
     # Formオブジェクトの値をビルドしたsleep_logの子モデルにセット


### PR DESCRIPTION
close #122

# 概要
mapメソッドの中で、各日付レコードごとに毎回1月分の検索findメソッドをかけていた問題を修正

# 主な変更
- `app/controllers/sleep_logs_controller.rb`で、その月の月初から月末までの睡眠記録を取得 / 日付だけ与えてビルドするset_sleep_logsメソッドについて
- 月初〜月末までレコードをmapメソッドで日別レコードとして回していく部分について、その中でfinsメソッドを使っていたがために最大31日✖️31日=961回分の検索が行われてしまっており、非効率だった

  ```
  @sleep_logs = all_dates.map do |sleep_date|
  sleep_logs.find { |sleep_log| sleep_log.sleep_date == sleep_date } || current_user.sleep_logs.build(sleep_date: sleep_date)
  end
  ``` 
  -  @sleep_logs = all_dates.map do |sleep_date|: 31日分のうちから1日分を選択(1/31)
  - sleep_logs.find: 再び31日分のうちからsleep_dateで指定された1日分を選択(1/31)

- そのため、sleep_logsで月初から月末までのデータを取得する段階で、sleep_dateをハッシュ化させる。sleep_dateをキーとして、バリュー(日付)に合致するデータを[sleep_date]にそのまま埋め込めるようにした。なので、findメソッドでいちいちsleep_dateを探す必要がなくなり、データ探索の無駄を省いた