### PR TITLE
#48 バリデーション表示を全て日本語にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  # I18n確認用
+  gem "i18n-tasks"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,8 +134,21 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    highline (3.1.2)
+      reline
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.15)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -352,6 +365,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.2)
     timeout (0.4.2)
     turbo-rails (2.0.16)
@@ -398,6 +413,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  i18n-tasks
   jbuilder
   jsbundling-rails
   meta-tags

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,10 +13,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def update_profile
     if current_user.update(account_update_params)
-      flash[:notice] = "ユーザー設定を更新しました"
+      flash[:notice] = t("flash.users.registrations.update_profile.success")
       redirect_to users_edit_profile_path
     else
-      flash.now[:alert] ="なんかユーザー設定にやらかしがあります"
+      flash.now[:alert] = t("flash.users.registrations.update_profile.failure")
       render :edit_profile
     end
   end
@@ -29,12 +29,20 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if current_user.update_with_password(password_update_params)
       # 自動ログアウトさせないように再ログイン
       bypass_sign_in(current_user)
-      flash[:notice] = "パスワードを更新しました"
+      flash[:notice] = t("flash.users.registrations.update_password.success")
       redirect_to root_path
     else
-      flash.now[:alert] ="なんかパスワードにやらかしがあります"
+      flash.now[:alert] = t("flash.users.registrations.update_password.failure")
       render :edit_password
     end
+  end
+
+  # DELETE /resource
+  def destroy
+    current_user.destroy
+    sign_out current_user
+    flash[:notice] = t("flash.users.registrations.destroy.success")
+    redirect_to new_user_session_path, status: :see_other
   end
 
   # GET /resource/sign_up
@@ -56,16 +64,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def update
   #   super
   # end
-
-  # DELETE /resource
-  def destroy
-    current_user.destroy
-    sign_out current_user
-    flash[:notice] = "すいみんにっしをご利用いただきありがとうございました。"
-    redirect_to new_user_session_path, status: :see_other
-  end
-
   # GET /resource/cancel
+
   # Forces the session data which is usually expired after sign
   # in to be expired now. This is useful if the user wants to
   # cancel oauth signing in/up in the middle of the process,

--- a/app/forms/sleep_log_form.rb
+++ b/app/forms/sleep_log_form.rb
@@ -133,19 +133,19 @@ class SleepLogForm
     return false if go_to_bed_at.blank? || fell_asleep_at.blank? || woke_up_at.blank? || leave_bed_at.blank?
     # go_to_bed_atがfell_asleep_atより後の日時だった場合
     if go_to_bed_at > fell_asleep_at
-      errors.add(:go_to_bed_at, go_to_bed_at_before_fell_asleep_at)
+      errors.add(:go_to_bed_at, :go_to_bed_at_before_fell_asleep_at)
     end
     # fell_asleep_atがwoke_up_atより後の日時だった場合
     if fell_asleep_at > woke_up_at
-      errors.add(:fell_asleep_at, fell_asleep_at_before_woke_up_at)
+      errors.add(:fell_asleep_at, :fell_asleep_at_before_woke_up_at)
     end
     # fell_asleep_atがleave_bed_atより後の日時だった場合
     if fell_asleep_at > leave_bed_at
-      errors.add(:fell_asleep_at, fell_asleep_at_before_leave_bed_at)
+      errors.add(:fell_asleep_at, :fell_asleep_at_before_leave_bed_at)
     end
     # woke_up_atがleave_bed_atより後の日時だった場合
     if woke_up_at > leave_bed_at
-      errors.add(:woke_up_at, woke_up_at_before_leave_bed_at)
+      errors.add(:woke_up_at, :woke_up_at_before_leave_bed_at)
     end
   end
 end

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -24,7 +24,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 md:gap-x-8 md:gap-y-4">
         <div>
           <%= f.label :go_to_bed_at, class: "block text-sm font-medium mb-1" %>
-          <%= f.time_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
+          <%= f.time_field :go_to_bed_at, class: "input w-full bg-primary #{f.object.errors[:go_to_bed_at].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
           <% if f.object.errors[:go_to_bed_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
           <% end %>
@@ -32,7 +32,7 @@
 
         <div>
           <%= f.label :fell_asleep_at, class: "block text-sm font-medium mb-1" %>
-          <%= f.time_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
+          <%= f.time_field :fell_asleep_at, class: "input w-full bg-primary #{f.object.errors[:fell_asleep_at].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
           <% if f.object.errors[:fell_asleep_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
           <% end %>
@@ -40,7 +40,7 @@
 
         <div>
           <%= f.label :woke_up_at, class: "block text-sm font-medium mb-1" %>
-          <%= f.time_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
+          <%= f.time_field :woke_up_at, class: "input w-full bg-primary #{f.object.errors[:woke_up_at].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
           <% if f.object.errors[:woke_up_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
           <% end %>
@@ -48,7 +48,7 @@
 
         <div>
           <%= f.label :leave_bed_at, class: "block text-sm font-medium mb-1" %>
-          <%= f.time_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
+          <%= f.time_field :leave_bed_at, class: "input w-full bg-primary #{f.object.errors[:leave_bed_at].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
           <% if f.object.errors[:leave_bed_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
           <% end %>
@@ -57,7 +57,7 @@
 
       <div>
         <%= f.label :awakenings_count, class: "block text-sm font-medium mb-1" %>
-        <%= f.number_field :awakenings_count, min: 0, class: "input input-bordered w-full bg-primary" %>
+        <%= f.number_field :awakenings_count, min: 0, class: "input w-full bg-primary #{f.object.errors[:awakenings_count].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
         <% if f.object.errors[:awakenings_count].any? %>
           <p class="text-error text-xs mt-1"><%= f.object.errors[:awakenings_count].join(", ") %></p>
         <% end %>
@@ -65,7 +65,7 @@
 
       <div>
         <%= f.label :napping_time, class: "block text-sm font-medium mb-1" %>
-        <%= f.number_field :napping_time, min: 0, class: "input input-bordered w-full bg-primary " %>
+        <%= f.number_field :napping_time, min: 0, class: "input w-full bg-primary #{f.object.errors[:napping_time].any? ? 'border-2 border-warning input-warning' : 'border-none input-accent'}" %>
         <% if f.object.errors[:napping_time].any? %>
           <p class="text-error text-xs mt-1"><%= f.object.errors[:napping_time].join(", ") %></p>
         <% end %>
@@ -77,7 +77,7 @@
         <%= f.label :comment, class: "block text-sm font-medium mb-1" %>
 
         <%= f.text_area :comment, maxlength: max_length,
-          class: "textarea textarea-bordered w-full bg-primary indent-1 text-sm resize-y",
+          class: "textarea w-full bg-primary indent-1 text-sm resize-y #{f.object.errors[:comment].any? ? 'border-2 border-warning textarea-warning' : 'border-none textarea-accent'}",
           placeholder: "昨夜はよく眠れましたか？　薬は飲みましたか？",
           data: {
             "character-counter-target": "input"
@@ -85,15 +85,11 @@
         <p class="text-end text-sm">
           <strong data-character-counter-target="counter"></strong>/<%= max_length %>文字
         </p>
-
-
       </div>
 
       <div>
         <%= f.submit sleep_log_form.new_record? ? "登録" : "更新", class: "flex w-full rounded rounded-md bg-accent hover:bg-blue-600 text-primary font-bold py-2 px-4"%>
       </div>
     </div>
-
-
   <% end %>
 </div>

--- a/app/views/sleep_logs/_form.html.erb
+++ b/app/views/sleep_logs/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div class="flex flex-col space-y-4">
       <div class="mb-4">
-        <%= f.label :sleep_date, '起きた日付', class: "block text-sm font-medium mb-1" %>
+        <%= f.label :sleep_date, class: "block text-sm font-medium mb-1" %>
         <% display_date = (f.object.sleep_date.presence || params[:sleep_date]) %>
         <% display_date = display_date.to_date if display_date.is_a?(String) %>
         <p class="text-base font-semibold "><%= display_date.strftime('%Y年%-m月%-d日') if display_date.present? %></p>
@@ -23,7 +23,7 @@
 
       <div class="grid grid-cols-1 md:grid-cols-2 md:gap-x-8 md:gap-y-4">
         <div>
-          <%= f.label :go_to_bed_at, "昨夜布団に入った時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.label :go_to_bed_at, class: "block text-sm font-medium mb-1" %>
           <%= f.time_field :go_to_bed_at, class: "input input-bordered w-full bg-primary" %>
           <% if f.object.errors[:go_to_bed_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:go_to_bed_at].join(", ") %></p>
@@ -31,7 +31,7 @@
         </div>
 
         <div>
-          <%= f.label :fell_asleep_at, "昨夜寝た時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.label :fell_asleep_at, class: "block text-sm font-medium mb-1" %>
           <%= f.time_field :fell_asleep_at, class: "input input-bordered w-full bg-primary" %>
           <% if f.object.errors[:fell_asleep_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:fell_asleep_at].join(", ") %></p>
@@ -39,7 +39,7 @@
         </div>
 
         <div>
-          <%= f.label :woke_up_at, "今朝目覚めた時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.label :woke_up_at, class: "block text-sm font-medium mb-1" %>
           <%= f.time_field :woke_up_at, class: "input input-bordered w-full bg-primary " %>
           <% if f.object.errors[:woke_up_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:woke_up_at].join(", ") %></p>
@@ -47,7 +47,7 @@
         </div>
 
         <div>
-          <%= f.label :leave_bed_at, "今朝布団から出た時刻", class: "block text-sm font-medium mb-1" %>
+          <%= f.label :leave_bed_at, class: "block text-sm font-medium mb-1" %>
           <%= f.time_field :leave_bed_at, class: "input input-bordered w-full bg-primary" %>
           <% if f.object.errors[:leave_bed_at].any? %>
             <p class="text-error text-xs mt-1"><%= f.object.errors[:leave_bed_at].join(", ") %></p>
@@ -56,7 +56,7 @@
       </div>
 
       <div>
-        <%= f.label :awakenings_count, "中途覚醒（回数）", class: "block text-sm font-medium mb-1" %>
+        <%= f.label :awakenings_count, class: "block text-sm font-medium mb-1" %>
         <%= f.number_field :awakenings_count, min: 0, class: "input input-bordered w-full bg-primary" %>
         <% if f.object.errors[:awakenings_count].any? %>
           <p class="text-error text-xs mt-1"><%= f.object.errors[:awakenings_count].join(", ") %></p>
@@ -64,7 +64,7 @@
       </div>
 
       <div>
-        <%= f.label :napping_time, "昼寝時間（分）", class: "block text-sm font-medium mb-1" %>
+        <%= f.label :napping_time, class: "block text-sm font-medium mb-1" %>
         <%= f.number_field :napping_time, min: 0, class: "input input-bordered w-full bg-primary " %>
         <% if f.object.errors[:napping_time].any? %>
           <p class="text-error text-xs mt-1"><%= f.object.errors[:napping_time].join(", ") %></p>
@@ -74,7 +74,7 @@
       <!-- 最大文字数取得 -->
       <% max_length = SleepLogForm.validators_on(:comment).find { |v| v.kind == :length }.options[:maximum] %>
       <div data-controller="character-counter">
-        <%= f.label :comment, "備考", class: "block text-sm font-medium mb-1" %>
+        <%= f.label :comment, class: "block text-sm font-medium mb-1" %>
 
         <%= f.text_area :comment, maxlength: max_length,
           class: "textarea textarea-bordered w-full bg-primary indent-1 text-sm resize-y",

--- a/app/views/users/registrations/edit_password.html.erb
+++ b/app/views/users/registrations/edit_password.html.erb
@@ -10,14 +10,14 @@
 
         <!-- パスワード -->
         <div>
-          <%= f.label :current_password, "今のパスワード", class: "block text-sm/6 font-medium"%>
+          <%= f.label :current_password, t("activerecord.attributes.user.current_password"), class: "block text-sm/6 font-medium"%>
           <div class="mt-2">
             <%= f.password_field :current_password, autocomplete: "current-password" , class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
           </div>
         </div>
 
         <div class="flex items-center justify-between">
-          <%= f.label :password, "新しいパスワード", class: "block text-sm/6 font-medium"%>
+          <%= f.label :password,  t("activerecord.attributes.user.password"), class: "block text-sm/6 font-medium"%>
         </div>
         <% if @minimum_password_length %>
           <em class="text-sm text-gray-500">(<%= @minimum_password_length %>文字以上でしくよろ)</em>
@@ -27,7 +27,7 @@
         </div>
 
         <div>
-          <%= f.label :password_confirmation, "新しいパスワード確認", class: "block text-sm/6 font-medium"%>
+          <%= f.label :password_confirmation,  t("activerecord.attributes.user.password_confirmation"), class: "block text-sm/6 font-medium"%>
           <div class="mt-2">
             <%= f.password_field :password_confirmation, autocomplete: "new-password" , class: "input input-sm w-full rounded-md bg-primary px-3 py-1.5 outline outline-1 -outline-offset-1 outline-secondary" %>
           </div>
@@ -35,13 +35,13 @@
       </div>
 
       <div class="actions mt-10 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 font-semibold text-primary shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-        <%= f.submit "パスワードを変更する"%>
+        <%= f.submit t("helpers.submit.update")%>
       </div>
     <% end %>
 
     <div class="mt-8 text-center">
       <div>
-        <%= link_to "ユーザー設定に戻る", users_edit_profile_path %>
+        <%= link_to t("views.links.back_to_user_edit"), users_edit_profile_path %>
       </div>
     </div>
   </div>

--- a/app/views/users/registrations/edit_profile.html.erb
+++ b/app/views/users/registrations/edit_profile.html.erb
@@ -26,17 +26,17 @@
       </div>
 
         <div class="actions mt-10 flex w-full justify-center rounded-md bg-accent px-3 py-1.5 font-semibold text-primary shadow-sm">
-          <%= f.submit "更新"%>
+          <%= f.submit t("helpers.submit.create") %>
         </div>
     <% end %>
 
     <div class="mt-10 text-center">
       <div>
-        <%= link_to "パスワード変更", :users_edit_password %>
+        <%= link_to t("views.links.change_password"), :users_edit_password %>
       </div>
 
       <div class="mt-4 text-warning">
-        <%= link_to "退会はこちら", :users_unsubscribe_confirm %>
+        <%= link_to t("views.links.unsubscribe"), :users_unsubscribe_confirm %>
       </div>
     </div>
   </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -8,18 +8,18 @@
 
         <div class="form-control space-y-1 md:space-y-4">
           <div>
-            <%= f.label :name, "お名前", class: "label text-sm md:text-base" %>
+            <%= f.label :name, t("activerecord.attributes.user.name"), class: "label text-sm md:text-base" %>
             <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "お名前を入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <div>
-            <%= f.label :email, "メールアドレス", class: "label text-sm md:text-base" %>
+            <%= f.label :email, t("activerecord.attributes.user.email"), class: "label text-sm md:text-base" %>
             <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレスを入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <div>
             <div class="flex items-center justify-between">
-              <%= f.label :password, "パスワード", class: "label text-sm md:text-base" %>
+              <%= f.label :password, t("activerecord.attributes.user.encrypted_password"), class: "label text-sm md:text-base" %>
               <% if @minimum_password_length %>
                 <span class="label-text-alt text-xs md:text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
               <% end %>
@@ -28,13 +28,13 @@
           </div>
 
           <div>
-            <%= f.label :password_confirmation, "パスワード確認", class: "label text-sm md:text-base" %>
+            <%= f.label :password_confirmation, t("activerecord.attributes.user.encrypted_password_confirmation"), class: "label text-sm md:text-base" %>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを再入力", class: "input input-bordered w-full bg-primary" %>
           </div>
         </div>
 
         <div class="actions mt-6 md:mt-8">
-          <%= f.submit "登録", class: "btn btn-accent w-full text-sm md:text-base" %>
+          <%= f.submit t("helpers.submit.create"), class: "btn btn-accent w-full text-sm md:text-base" %>
         </div>
       </fieldset>
     <% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -9,14 +9,14 @@
         <div class="form-control space-y-4">
           <!-- メールアドレス -->
           <div>
-            <%= f.label :email, "メールアドレス", class: "label" %>
+            <%= f.label :email, t("activerecord.attributes.user.email"), class: "label" %>
             <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレスを入力", class: "input input-bordered w-full bg-primary" %>
           </div>
 
           <!-- パスワード -->
           <div>
             <div class="flex items-center justify-between">
-              <%= f.label :password, "パスワード", class: "label" %>
+              <%= f.label :password, t("activerecord.attributes.user.encrypted_password"), class: "label" %>
               <% if @minimum_password_length %>
                 <span class="label-text-alt text-sm text-gray-500">(<%= @minimum_password_length %>文字以上)</span>
               <% end %>
@@ -27,12 +27,12 @@
           <div class="flex items-center">
             <% if devise_mapping.rememberable? %>
               <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
-              <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-neutral" %>
+              <%= f.label :remember_me, t("activerecord.attributes.user.remember_me"), class: "ml-2 block text-sm text-neutral" %>
             <% end %>
           </div>
 
         <div class="actions">
-          <%= f.submit "ログイン", class: "btn btn-accent w-full" %>
+          <%= f.submit t("views.submits.login"), class: "btn btn-accent w-full" %>
         </div>
       </fieldset>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,8 @@ module SleepLogger
 
     # デフォルト言語を日本語に
     config.i18n.default_locale = :ja
+
+    # localesディレクトリの中のファイルを再帰的に探す
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,6 @@ module SleepLogger
     config.i18n.default_locale = :ja
 
     # localesディレクトリの中のファイルを再帰的に探す
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
   end
 end

--- a/config/locales/flash/ja.yml
+++ b/config/locales/flash/ja.yml
@@ -1,0 +1,13 @@
+ja:
+  flash:
+    users:
+      registrations:
+        update_profile:
+          success: "ユーザー設定を更新しました"
+          failure: "なんかユーザー設定にやらかしがあります"
+        update_password:
+          success: "パスワードを更新しました"
+          failure: "なんかパスワードにやらかしがあります"
+        destroy:
+          success: "すいみんにっしをご利用いただきありがとうございました。"
+

--- a/config/locales/forms/sleep_log_form.ja.yml
+++ b/config/locales/forms/sleep_log_form.ja.yml
@@ -13,14 +13,14 @@ ja:
         awakenings_count: 中途覚醒回数
         napping_time: 昼寝時間
         comment: 備考
-  errors:
-    models:
-      sleep_log_form:
-        attributes:
-          go_to_bed_at:
-            go_to_bed_at_before_fell_asleep_at: "は昨夜寝た時刻より前の時刻にしてください"
-          fell_asleep_at:
-            fell_asleep_at_before_woke_up_at: "は今朝目覚めた時刻より前の時刻にしてください"
-            fell_asleep_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
-          woke_up_at:
-            woke_up_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
+    errors:
+      models:
+        sleep_log_form:
+          attributes:
+            go_to_bed_at:
+              go_to_bed_at_before_fell_asleep_at: "は昨夜寝た時刻より前の時刻にしてください"
+            fell_asleep_at:
+              fell_asleep_at_before_woke_up_at: "は今朝目覚めた時刻より前の時刻にしてください"
+              fell_asleep_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
+            woke_up_at:
+              woke_up_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"

--- a/config/locales/forms/sleep_log_form.ja.yml
+++ b/config/locales/forms/sleep_log_form.ja.yml
@@ -1,0 +1,26 @@
+ja:
+  activemodel:
+    models:
+      sleep_log_form: 睡眠記録フォーム
+    attributes:
+      sleep_log_form:
+        user_id: ユーザID
+        sleep_date: 起きた日付
+        go_to_bed_at: 昨夜布団に入った時刻
+        fell_asleep_at: 昨夜寝た時刻
+        woke_up_at: 今朝目覚めた時刻
+        leave_bed_at: 今朝布団から出た時刻
+        awakenings_count: 中途覚醒回数
+        napping_time: 昼寝時間
+        comment: 備考
+  errors:
+    models:
+      sleep_log_form:
+        attributes:
+          go_to_bed_at:
+            go_to_bed_at_before_fell_asleep_at: "は昨夜寝た時刻より前の時刻にしてください"
+          fell_asleep_at:
+            fell_asleep_at_before_woke_up_at: "は今朝目覚めた時刻より前の時刻にしてください"
+            fell_asleep_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
+          woke_up_at:
+            woke_up_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"

--- a/config/locales/forms/sleep_log_form.ja.yml
+++ b/config/locales/forms/sleep_log_form.ja.yml
@@ -11,16 +11,16 @@ ja:
         woke_up_at: 今朝目覚めた時刻
         leave_bed_at: 今朝布団から出た時刻
         awakenings_count: 中途覚醒回数
-        napping_time: 昼寝時間
-        comment: 備考
+        napping_time: 昼寝時間(分)
+        comment: 備考(42文字まで)
     errors:
       models:
         sleep_log_form:
           attributes:
             go_to_bed_at:
-              go_to_bed_at_before_fell_asleep_at: "は昨夜寝た時刻より前の時刻にしてください"
+              go_to_bed_at_before_fell_asleep_at: "は、昨夜寝た時刻より前の時刻にしてください"
             fell_asleep_at:
-              fell_asleep_at_before_woke_up_at: "は今朝目覚めた時刻より前の時刻にしてください"
-              fell_asleep_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
+              fell_asleep_at_before_woke_up_at: "は、今朝目覚めた時刻より前の時刻にしてください"
+              fell_asleep_at_before_leave_bed_at: "は、今朝布団から出た時刻より前の時刻にしてください"
             woke_up_at:
-              woke_up_at_before_leave_bed_at: "は今朝布団から出た時刻より前の時刻にしてください"
+              woke_up_at_before_leave_bed_at: "は、今朝布団から出た時刻より前の時刻にしてください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  views:
+    links:
+      change_password: パスワード変更
+      unsubscribe: 退会はこちら
+  helpers:
+    submit:
+      create: 登録
+      update: 更新

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,9 +1,11 @@
 ja:
   views:
+    submits:
+      login: ログイン
     links:
       change_password: パスワード変更
       unsubscribe: 退会はこちら
-      :back_to_user_edit: ユーザー設定に戻る
+      back_to_user_edit: ユーザー設定に戻る
   helpers:
     submit:
       create: 登録

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     links:
       change_password: パスワード変更
       unsubscribe: 退会はこちら
+      :back_to_user_edit: ユーザー設定に戻る
   helpers:
     submit:
       create: 登録

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -15,6 +15,7 @@ ja:
         reset_password_token: リセットパスワードトークン
         reset_password_sent_at: リセットパスワード送信タイミング
         remember_created_at: パスワードの記憶
+        remember_me: ログイン状態を保持する
         current_password: 今のパスワード
         password: 新しいパスワード
         password_confirmation: 新しいパスワード確認

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,37 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      sns_credential: SNSクレデンシャル
+      sleep_log: 睡眠記録
+      awakening: 中途覚醒
+      napping_time: 昼寝
+      comment: コメント
+    attributes:
+      user:
+        name: お名前
+        email: メールアドレス
+        encrypted_password: パスワード
+        reset_password_token: リセットパスワードトークン
+        reset_password_sent_at: リセットパスワード送信タイミング
+        remember_created_at: パスワードの記憶
+      sns_credential: {}
+      sleep_log:
+        go_to_bed_at: 昨夜布団に入った時刻
+        fell_asleep_at: 昨夜寝た時刻
+        woke_up_at: 今朝目覚めた時刻
+        leave_bed_at: 今朝布団から出た時刻
+        sleep_date: 起きた日付
+      awakening: 
+        awakenings_count: 中途覚醒回数
+      napping_time:
+        napping_time: 昼寝時間
+      comment:
+        comment: 備考
+
+      created_at: 作成日
+      updated_at: 更新日
+      provider: プロバイダ
+      uid: UID
+      user_id: ユーザID
+      sleep_log_id: 睡眠記録ID

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -15,6 +15,9 @@ ja:
         reset_password_token: リセットパスワードトークン
         reset_password_sent_at: リセットパスワード送信タイミング
         remember_created_at: パスワードの記憶
+        current_password: 今のパスワード
+        password: 新しいパスワード
+        password_confirmation: 新しいパスワード確認
       sns_credential: {}
       sleep_log:
         go_to_bed_at: 昨夜布団に入った時刻

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -12,6 +12,7 @@ ja:
         name: お名前
         email: メールアドレス
         encrypted_password: パスワード
+        encrypted_password_confirmation: パスワード確認
         reset_password_token: リセットパスワードトークン
         reset_password_sent_at: リセットパスワード送信タイミング
         remember_created_at: パスワードの記憶


### PR DESCRIPTION
close #124 

# 概要
バリデーションが英語のままになっているのを、i18nなどを使って全て日本語表記にする

# 主な変更
- エラーの際に文言として出てしまいそうな値を中心に変更
- 例えば、タイトル名やフラッシュメッセージの部分など、英語として出てしまわない部分は一旦保留中

# フィードバック
新規登録フォーム（その他フォームも同様）でのバリデーションメッセージが英語になっていたので、日本語にした方がより親切だと感じました
画像を貼付できないので説明しづらいですがバリデーションエラーのメッセージにそのままフィールド名で出ちゃっています

# Lintチェック
<img width="735" height="138" alt="image" src="https://github.com/user-attachments/assets/ec93ef57-a1e0-4e2b-b8f5-3423005ac36d" />